### PR TITLE
fix: metrics server error

### DIFF
--- a/stage1/roles/localhost_post_setup/tasks/install-metrics-server.yml
+++ b/stage1/roles/localhost_post_setup/tasks/install-metrics-server.yml
@@ -13,3 +13,6 @@
     create_namespace: true
     values:
       replicas: 1
+      args: ['--kubelet-insecure-tls']
+      serviceMonitor:
+        enabled: true


### PR DESCRIPTION
In this PR, I've fixed the error with metrics server due to 
```
failed to verify certificate: x509: cannot validate certificate
```