### PR TITLE
fix: Prometheus scrape for kube-system components

### DIFF
--- a/stage1/roles/kubeadm_server/tasks/initialise-kubeadm.yml
+++ b/stage1/roles/kubeadm_server/tasks/initialise-kubeadm.yml
@@ -57,16 +57,27 @@
   changed_when: false
   ignore_errors: true
 
-- name: Update kubeadm-config
+- name: Update kubeadm-config and kube-proxy configmap
   when: check_control_plane_endpoint.rc != 0
   block:
-    - name: Update kubeadm-config configmap
+    - name: Update kubeadm-config configmap to bind control plane endpoint to host IP
       ansible.builtin.shell: |
         set -o pipefail && \
         kubectl -n kube-system get configmap kubeadm-config -o json |
         jq 'if (.data.ClusterConfiguration | contains("controlPlaneEndpoint")) then
         .data.ClusterConfiguration |= sub("controlPlaneEndpoint: .*"; "controlPlaneEndpoint: {{ ansible_host }}:6443")
         else .data.ClusterConfiguration |= . + "\ncontrolPlaneEndpoint: {{ ansible_host }}:6443" end' |
+        kubectl apply -f -
+      args:
+        executable: /bin/bash
+      changed_when: false
+    - name: Update kube-proxy configmap to bind metrics endpoint to 0.0.0.0
+      ansible.builtin.shell: |
+        set -o pipefail && \
+        kubectl -n kube-system get configmap kube-proxy -o json |
+        jq 'if (.data."config.conf" | contains("metricsBindAddress")) then
+        .data."config.conf" |= sub("metricsBindAddress: .*"; "metricsBindAddress: \"0.0.0.0:10249\"")
+        else .data."config.conf" |= . + "\nmetricsBindAddress: \"0.0.0.0:10249\"" end' |
         kubectl apply -f -
       args:
         executable: /bin/bash

--- a/stage1/roles/kubeadm_server/templates/kubeadm-config.yaml.j2
+++ b/stage1/roles/kubeadm_server/templates/kubeadm-config.yaml.j2
@@ -1,6 +1,25 @@
 kind: ClusterConfiguration
 apiVersion: kubeadm.k8s.io/v1beta4
 kubernetesVersion: v{{ kubeadm_version }}
+# https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/kube-prometheus-on-kubeadm.md
+apiServer:
+  extraArgs:
+    - name: authorization-mode
+      value: "Node,RBAC"
+controllerManager:
+  extraArgs:
+    - name: bind-address
+      value: "0.0.0.0"
+scheduler:
+  extraArgs:
+    - name: bind-address
+      value: "0.0.0.0"
+# https://github.com/prometheus-community/helm-charts/issues/204#issuecomment-1003558431
+etcd:
+  local:
+    extraArgs:
+      - name: listen-metrics-urls:
+        value: 'http://0.0.0.0:2381'
 ---
 kind: InitConfiguration
 apiVersion: kubeadm.k8s.io/v1beta4

--- a/stage2/logging/templates/eck/filebeat.tftpl
+++ b/stage2/logging/templates/eck/filebeat.tftpl
@@ -58,8 +58,6 @@ spec:
         when:
           or:
           - equals:
-              kubernetes.namespace: kube-system
-          - equals:
               kubernetes.namespace: logging
           - equals:
               kubernetes.namespace: prometheus

--- a/stage2/prometheus-stack/templates/prometheus-stack-values.tftpl
+++ b/stage2/prometheus-stack/templates/prometheus-stack-values.tftpl
@@ -4,11 +4,6 @@
 ##
 defaultRules:
   create: true
-  ## Disabled PrometheusRule alerts
-  disabled:
-    KubeControllerManagerDown: true
-    KubeProxyDown: true
-    KubeSchedulerDown: true
 
 ## Configuration for alertmanager
 ## ref: https://prometheus.io/docs/alerting/alertmanager/


### PR DESCRIPTION
- Patch kube-proxy to expose metrics to Prometheus
- Update kubeadm-config to expose api server, controller manager, scheduler and etcd metrics
- Update filebeat to collect kube-system logs
- Remove Prometheus disabled kube components