### PR TITLE
fix: Upgrade Gitlab and fix Gitlab Runner registration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -67,6 +67,10 @@ TF_VAR_gitlab_certmanager_issuer_email="chris@${domain_host}"
 TF_VAR_gitlab_postgresql_primary_persistence_size=20Gi
 TF_VAR_gitlab_redis_master_persistence_size=20Gi
 TF_VAR_gitlab_gitlay_persistence_size=20Gi
+# Go to Admin area -> CI/CD -> Runners -> New instance runner
+# Make sure to set `Run untagged jobs`
+# Copy token and paste here
+TF_VAR_gitlab_runner_authentication_token=
 
 # Prometheus Stack
 TF_VAR_prometheus_alertmanager_domain="alertmanager.${domain_host}"

--- a/stage2/gitlab-platform/gitlab.tf
+++ b/stage2/gitlab-platform/gitlab.tf
@@ -12,7 +12,6 @@ resource "helm_release" "gitlab" {
     kubernetes_secret.redis_password,
     kubernetes_secret.rails_secret,
     kubernetes_secret.postgresql_password,
-    kubernetes_secret.runner_registration_token,
     kubernetes_secret.gitlab_runner_s3_access,
     kubernetes_secret.gitlab_shell_secret,
     kubernetes_secret.gitaly_secret,
@@ -26,7 +25,7 @@ resource "helm_release" "gitlab" {
   name       = "gitlab"
   repository = "https://charts.gitlab.io/"
   chart      = "gitlab"
-  version    = "8.4.2"
+  version    = "8.5.0"
   namespace  = kubernetes_namespace.gitlab.metadata[0].name
   timeout    = 600 # 10 minutes
   wait       = true
@@ -47,14 +46,14 @@ resource "helm_release" "gitlab" {
         global_ingress_class      = var.gitlab_global_ingress_class
         global_ingress_enable_tls = var.gitlab_global_ingress_enable_tls
 
-        global_initial_root_password_secret     = kubernetes_secret.initial_root_password.metadata[0].name
-        global_redis_secret                     = kubernetes_secret.redis_password.metadata[0].name
-        global_postgresql_password_secret       = kubernetes_secret.postgresql_password.metadata[0].name
-        global_rails_secrets                    = kubernetes_secret.rails_secret.metadata[0].name
-        global_runner_registration_token_secret = kubernetes_secret.runner_registration_token.metadata[0].name
-        global_shell_auth_token_secret          = kubernetes_secret.gitlab_shell_secret.metadata[0].name
-        global_shell_host_keys_secret           = kubernetes_secret.gitlab_shell_host_keys.metadata[0].name
-        global_gitaly_auth_token_secret         = kubernetes_secret.gitaly_secret.metadata[0].name
+        global_initial_root_password_secret = kubernetes_secret.initial_root_password.metadata[0].name
+        global_redis_secret                 = kubernetes_secret.redis_password.metadata[0].name
+        global_postgresql_password_secret   = kubernetes_secret.postgresql_password.metadata[0].name
+        global_rails_secrets                = kubernetes_secret.rails_secret.metadata[0].name
+
+        global_shell_auth_token_secret  = kubernetes_secret.gitlab_shell_secret.metadata[0].name
+        global_shell_host_keys_secret   = kubernetes_secret.gitlab_shell_host_keys.metadata[0].name
+        global_gitaly_auth_token_secret = kubernetes_secret.gitaly_secret.metadata[0].name
 
         object_store_connection_secret = kubernetes_secret.gitlab_object_store_connection.metadata[0].name
         registry_http_secret           = kubernetes_secret.gitlab_registry_httpsecret.metadata[0].name
@@ -63,6 +62,10 @@ resource "helm_release" "gitlab" {
 
         runner_s3_access_secret = kubernetes_secret.gitlab_runner_s3_access.metadata[0].name
         toolbox_s3cmd_secret    = kubernetes_secret.gitlab_toolbox_s3cmd.metadata[0].name
+
+        gitlab_runner_gitlab_url           = var.gitlab_global_hosts_https ? "https://gitlab.${var.gitlab_global_hosts_domain}" : "http://gitlab.${var.gitlab_global_hosts_domain}"
+        gitlab_runner_authentication_token = var.gitlab_runner_authentication_token
+        gitlab_runner_token_secret         = kubernetes_secret.runner_token.metadata[0].name
 
         certmanager_issuer_email = var.gitlab_certmanager_issuer_email
 

--- a/stage2/gitlab-platform/output.tf
+++ b/stage2/gitlab-platform/output.tf
@@ -3,11 +3,6 @@ output "gitlab_initial_root_password" {
   sensitive = true
 }
 
-output "gitlab_runner_registration_token" {
-  value     = random_password.runner_registration_token.result
-  sensitive = true
-}
-
 output "gitlab_shell_host_keys" {
   value     = data.external.generate_keys.result
   sensitive = true

--- a/stage2/gitlab-platform/templates/gitlab-values.tftpl
+++ b/stage2/gitlab-platform/templates/gitlab-values.tftpl
@@ -265,13 +265,12 @@ global:
       enabled: true
     sessionStore:
       sessionCookieTokenPrefix: ""
-
   ## GitLab Runner
-  ## Secret created according to https://docs.gitlab.com/charts/installation/secrets#gitlab-runner-secret
-  ## If allowing shared-secrets generation, this is OPTIONAL.
+  # Should set to arbitrary value; otherwise, Gitlab chart will generate the secret with registration token, which is not compatible with Gitlab Runner chart.
+  # Here: https://gitlab.com/gitlab-org/charts/gitlab/-/blob/master/templates/shared-secrets/_generate_secrets.sh.tpl?ref_type=heads#L105
   runner:
     registrationToken:
-      secret: ${global_runner_registration_token_secret}
+      secret: "gitlab-gitlab-runner-secret-deprecated"
 
   ## https://docs.gitlab.com/charts/charts/globals#outgoing-email
   ## Outgoing email server settings
@@ -755,24 +754,18 @@ gitlab-runner:
   envVars:
     - name: RUNNER_ENV
       value: "DOCKER_TLS_CERTDIR=/certs"
-    - name: REGISTER_RUN_UNTAGGED
-      value: "true"
+  gitlabUrl: ${gitlab_runner_gitlab_url}
+  # Must define runnerToken; so, the chart can generate the secret. Cannot use pre-generated secret.
+  runnerToken: ${gitlab_runner_authentication_token}
+  # secret: ${gitlab_runner_token_secret}
   runners:
-    locked: false
     privileged: true
-    # Set secret to an arbitrary value because the runner chart renders the gitlab-runner.secret template only if it is not empty.
-    # The parent/GitLab chart overrides the template to render the actual secret name.
-    # https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#docker-in-docker-with-tls-enabled-in-kubernetes
-    # https://docs.gitlab.com/runner/executors/kubernetes/index.html#exposed-varrundockersock
-    # https://stackoverflow.com/questions/72490488/user-systemserviceaccountgitlabdefault-cannot-get-resource-deployments-in
-    secret: ${global_runner_registration_token_secret}
     config: |
       [[runners]]
         [runners.kubernetes]
           namespace = "{{.Release.Namespace}}"
           image = "docker:stable"
           privileged = true
-          # service_account = "gitlab-gitlab-runner"
           [runners.cache]
             Type = "s3"
             Path = "gitlab-runner"

--- a/stage2/gitlab-platform/variables.tf
+++ b/stage2/gitlab-platform/variables.tf
@@ -119,3 +119,10 @@ variable "gitlab_gitlay_persistence_size" {
   type        = string
   default     = "20Gi"
 }
+
+variable "gitlab_runner_authentication_token" {
+  description = "The authentication token for the gitlab runner. Refer https://git.math.duke.edu/gitlab/help/ci/runners/new_creation_workflow.md"
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/stage2/main.tf
+++ b/stage2/main.tf
@@ -76,7 +76,6 @@ module "gitlab_platform" {
   gitlab_minio_host     = "minio.minio-tenant.svc.cluster.local"
   gitlab_minio_endpoint = "http://minio.minio-tenant.svc.cluster.local"
 
-
   gitlab_minio_access_key = var.minio_tenant_user_access_key
   gitlab_minio_secret_key = module.minio_object_storage.minio_tenant_user_secret_key
 
@@ -87,6 +86,8 @@ module "gitlab_platform" {
   gitlab_postgresql_primary_persistence_size = var.gitlab_postgresql_primary_persistence_size
   gitlab_redis_master_persistence_size       = var.gitlab_redis_master_persistence_size
   gitlab_gitlay_persistence_size             = var.gitlab_gitlay_persistence_size
+
+  gitlab_runner_authentication_token = var.gitlab_runner_authentication_token
 }
 
 

--- a/stage2/output.tf
+++ b/stage2/output.tf
@@ -14,11 +14,6 @@ output "gitlab_initial_root_passwrd" {
   sensitive = true
 }
 
-output "gitlab_runner_registration_token" {
-  value     = length(module.gitlab_platform) > 0 ? module.gitlab_platform[0].gitlab_runner_registration_token : null
-  sensitive = true
-}
-
 output "gitlab_shell_host_keys" {
   value     = length(module.gitlab_platform) > 0 ? module.gitlab_platform[0].gitlab_shell_host_keys : null
   sensitive = true

--- a/stage2/variables.tf
+++ b/stage2/variables.tf
@@ -229,6 +229,13 @@ variable "gitlab_gitlay_persistence_size" {
   default     = "20Gi"
 }
 
+variable "gitlab_runner_authentication_token" {
+  description = "The authentication token for the gitlab runner. Refer https://git.math.duke.edu/gitlab/help/ci/runners/new_creation_workflow.md"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "prometheus_alertmanager_domain" {
   description = "The domain name for the alertmanager"
   type        = string


### PR DESCRIPTION
**Changes:**

- Upgrade Gitlab Helm chart to `8.5.0`
- Fix Gitlab Runner to use an authentication token instead of a registration token 

**Errors encountered**

```
Runner configuration other than name and executor configuration is reserved (specifically --locked, --access-level, --run-untagged, --maximum-timeout, --paused, --tag-list, and --maintenance-note) and cannot be specified when registering with a runner authentication token. This configuration is specified on the GitLab server. Please try again without specifying any of those arguments. For more information, see https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html#changes-to-the-gitlab-runner-register-command-syntax
```

```
Registering runner... forbidden (check registration token) runner status POST https://gitlab.chrislee.local/api/v4/runners: 403 Forbidden (403 Forbidden - invalid token supplied)
```

```
ERROR: Verifying runner... is removed runner status POST https://gitlab.chrislee.local/api/v4/runners/verify: 403 Forbidden
```

