### PR TITLE
fix: right-sizing for argocd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN set -eux; \
   g++=13.2.1_git20240309-r0 \
   gcc=13.2.1_git20240309-r0 \
   libffi-dev=3.4.6-r0	\
-  python3-dev=3.12.8-r1 \
+  python3-dev=3.12.9-r0 \
   py3-pip=24.0-r2 && \
   # Setup Python virtual environment
   python3 -m venv .venv && \

--- a/stage2/argocd/templates/argocd-values.tftpl
+++ b/stage2/argocd/templates/argocd-values.tftpl
@@ -741,7 +741,7 @@ controller:
   resources:
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1024Mi
     requests:
       cpu: 155m
       memory: 779Mi
@@ -2582,7 +2582,7 @@ repoServer:
   # -- Resource limits and requests for the repo server pods
   resources:
     limits:
-      cpu: 50m
+      cpu: 100m
       memory: 200Mi
     requests:
       cpu: 10m


### PR DESCRIPTION
- Fix ArgoCD right-sizing

```
[1  Alerts]
Alert: Processes experience elevated CPU throttling.
Description: 29.25% throttling of CPU in namespace argocd for container repo-server in pod argocd-repo-server-856d5586b4-llpv4.
Severity: info
Source: Prometheus Alertmanager
```