### PR TITLE
fix: elasticsearch to be warm node too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ RUN set -eux; \
   \
   apk add --no-cache \
   ca-certificates=20241121-r1 \
-  curl=8.12.0-r0 \
+  curl=8.12.1-r0 \
   bash=5.2.26-r0 \
   jq=1.7.1-r0 \
-  bind-tools=9.18.33-r0 \
+  bind-tools=9.18.37-r0 \
   git=2.45.3-r0 \
   && \
   \
@@ -53,12 +53,12 @@ RUN set -eux; \
   \
   # Install Ansible
   apk add --no-cache \
-  openssh=9.7_p1-r4 \
+  openssh=9.7_p1-r5 \
   sshpass=1.10-r0 \
-  g++=13.2.1_git20240309-r0 \
-  gcc=13.2.1_git20240309-r0 \
+  g++=13.2.1_git20240309-r1 \
+  gcc=13.2.1_git20240309-r1 \
   libffi-dev=3.4.6-r0	\
-  python3-dev=3.12.9-r0 \
+  python3-dev=3.12.10-r1 \
   py3-pip=24.0-r2 && \
   # Setup Python virtual environment
   python3 -m venv .venv && \

--- a/stage2/logging/templates/eck/elasticsearch.tftpl
+++ b/stage2/logging/templates/eck/elasticsearch.tftpl
@@ -17,6 +17,8 @@ spec:
     - name: default
       count: 1
       config:
+        node.roles:
+          ["master", "data_hot", "data_warm", "data_content", "ingest"]
         node.store.allow_mmap: false
         xpack.monitoring.collection.enabled: true
         logger.level: info
@@ -43,12 +45,12 @@ spec:
                   memory: ${resource_limit_memory} # 4Gi
                   cpu: ${resource_limit_cpu} # 2
       volumeClaimTemplates:
-       - metadata:
-          name: elasticsearch-data
-         spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: ${storage_size}
-          storageClassName: ${storage_class_name}
+        - metadata:
+            name: elasticsearch-data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: ${storage_size}
+            storageClassName: ${storage_class_name}


### PR DESCRIPTION
check-migration is because there is a warm node. Force to delete instead of warm stage.

```
curl -u elastic:${ELASTIC_PASS} -X GET "localhost:9200/*/_ilm/explain?filter_path=indices.*.step,indices.*.phase,indices.*.action"
{
  "indices": {
    ".ds-filebeat-custom-2025.03.01-000044": {
      "phase": "warm",
      "action": "migrate",
      "step": "check-migration"
    },
    ".ds-filebeat-custom-2025.03.01-000045": {
      "phase": "warm",
      "action": "migrate",
      "step": "check-migration"
    }
  }
```

Since it's a single node, mark ElasticSearch node.roles as `["master", "data_hot", "data_warm", "data_content", "ingest"]`