### PR TITLE
feat: OpenID Connect with oauth2-proxy + auth0

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,7 +31,7 @@ TF_VAR_ingress_enable_tls=true # If set false, it will not generate TLS certific
 # Kubernetes
 TF_VAR_host_machine_architecture="${host_machine_architecture}"
 TF_VAR_kubernetes_override_ip="${server_ssh_host}"
-TF_VAR_kubernetes_override_domains="minio.${domain_host} gitlab.${domain_host} registry.${domain_host} argocd.${domain_host}"
+TF_VAR_kubernetes_override_domains="minio.${domain_host} gitlab.${domain_host} registry.${domain_host} argocd.${domain_host} auth.${domain_host}"
 
 # Nginx
 TF_VAR_nginx_service_loadbalancer_ip="${server_ssh_host}"
@@ -45,7 +45,7 @@ TF_VAR_cert_manager_acme_email="chris@${domain_host}"
 TF_VAR_cert_manager_ingress_class=nginx
 TF_VAR_cert_manager_host_alias_ip="${server_ssh_host}"
 # Need hostaliases to workaround hairpin NAT issue.
-TF_VAR_cert_manager_host_alias_hostnames="longhorn.${domain_host},minio.${domain_host},minio-console.${domain_host},kas.${domain_host},gitlab.${domain_host},registry.${domain_host},alertmanager.${domain_host},grafana.${domain_host},prometheus.${domain_host},kibana.${domain_host},cost.${domain_host},argocd.${domain_host}"
+TF_VAR_cert_manager_host_alias_hostnames="longhorn.${domain_host},minio.${domain_host},minio-console.${domain_host},kas.${domain_host},gitlab.${domain_host},registry.${domain_host},alertmanager.${domain_host},grafana.${domain_host},prometheus.${domain_host},kibana.${domain_host},cost.${domain_host},argocd.${domain_host},auth.${domain_host}"
 
 # Longhorn
 TF_VAR_longhorn_default_settings_default_data_path=/var/lib/longhorn
@@ -129,3 +129,12 @@ TF_VAR_wireguard_port="${wireguard_port}"
 TF_VAR_argocd_domain="argocd.${domain_host}"
 TF_VAR_argocd_ssh_known_hosts_base64=""
 TF_VAR_argocd_config_repositories_json_encoded="[]"
+
+# OAuth2 Proxy + Auth0
+TF_VAR_auth_ingress_class_name=nginx
+TF_VAR_auth_oauth2_proxy_host="auth.${domain_host}"
+TF_VAR_auth_oauth2_proxy_cookie_domains="[\".${domain_host}\"]"
+TF_VAR_auth_oauth2_proxy_whitelist_domains="[\"*.${domain_host}\"]"
+TF_VAR_auth_auth0_domain=
+TF_VAR_auth_auth0_client_id=
+TF_VAR_auth_auth0_client_secret=

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
     "autodiscover",
     "blockinfile",
     "certmanager",
+    "chrislee",
     "chrisleekr",
     "containerd",
     "crds",

--- a/stage2/argocd/argocd.tf
+++ b/stage2/argocd/argocd.tf
@@ -22,6 +22,7 @@ resource "helm_release" "argo_cd" {
       argocd_ingress_class_name        = var.argocd_ingress_class_name
       argocd_ssh_known_hosts_base64    = var.argocd_ssh_known_hosts_base64
       argocd_config_repositories       = var.argocd_config_repositories
+      auth_oauth2_proxy_host           = var.auth_oauth2_proxy_host
     })
   ]
 }

--- a/stage2/argocd/templates/argocd-values.tftpl
+++ b/stage2/argocd/templates/argocd-values.tftpl
@@ -2195,8 +2195,9 @@ server:
     ## Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/ingress/#option-1-ssl-passthrough
     annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
-      # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-      # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+      nginx.ingress.kubernetes.io/auth-url: "https://${auth_oauth2_proxy_host}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://${auth_oauth2_proxy_host}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token"
 
     # -- Defines which ingress controller will implement the resource
     ingressClassName: "${argocd_ingress_class_name}"

--- a/stage2/argocd/variables.tf
+++ b/stage2/argocd/variables.tf
@@ -52,3 +52,9 @@ variable "argocd_config_repositories" {
   }))
   default = []
 }
+
+variable "auth_oauth2_proxy_host" {
+  description = "The host for the oauth2 proxy"
+  type        = string
+  default     = "auth.chrislee.local"
+}

--- a/stage2/auth/.terraform.lock.hcl
+++ b/stage2/auth/.terraform.lock.hcl
@@ -1,0 +1,60 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.17.0"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.37.1"
+  constraints = ">= 2.31.0"
+  hashes = [
+    "h1:+37jC6JlkPyPvDHudK3qaj7ZVJ0Zy9zc9+oq8h1WayA=",
+    "zh:0ed097413c7fc804479e325966886b405dc0b75ad2b4f54ce4df1d8e4802b397",
+    "zh:17dcf4a685a00d2d048671124e8a1a8e836b58ecd2ef628a1c666fe0ced2e598",
+    "zh:36891284e5bced57c438f12d0b27856b0d4b70b562bd200b01919a6a89545be9",
+    "zh:3e49d86b508e641ba122d1b0af24cdc4d8ffa2ec1b30022436fb1d7c6ba696ea",
+    "zh:40be623e116708bdcb0fac32989db43720f031c5fe9a4dc63395078185d24403",
+    "zh:44fc0ac3bc39e289b67f9dde7ee9fef29eb8192197e5e68fee69098573021722",
+    "zh:957aa451573bcde5d57f6f8338ea3139010c7f61fefe8f6a140a8c267f056511",
+    "zh:c55fd85b7e8acaac17e30670ac3574b88b3530820dd004bcd2a5daa8624a46e9",
+    "zh:c743f06843a1f5ecde2b8ef639f4d3db654a334ef248dee57261c719ea843f3a",
+    "zh:c93cc71c64b838d89522ac5fb60f68e0e1e7f2fc39db6b0ead7afd78795e79ed",
+    "zh:eda1163c2266905adc54bc78cc3e7b606a164fbc6b59be607db933b302015ccd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/stage2/auth/namespace.tf
+++ b/stage2/auth/namespace.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_namespace" "auth_namespace" {
+  metadata {
+    name = "auth"
+  }
+}

--- a/stage2/auth/oauth2-proxy.tf
+++ b/stage2/auth/oauth2-proxy.tf
@@ -1,0 +1,56 @@
+# Generate cookie secret
+resource "random_password" "oauth2_proxy_cookie_secret" {
+  length  = 16
+  special = false
+}
+
+resource "kubernetes_secret" "oauth2_proxy_cookie_secret" {
+  metadata {
+    name      = "oauth2-proxy-cookie-secret"
+    namespace = kubernetes_namespace.auth_namespace.metadata[0].name
+  }
+
+  data = {
+    "client-id"     = var.auth_auth0_client_id
+    "client-secret" = var.auth_auth0_client_secret
+    "cookie-secret" = random_password.oauth2_proxy_cookie_secret.result
+  }
+
+  type = "Opaque"
+
+  lifecycle {
+    ignore_changes = [metadata[0].labels]
+  }
+}
+
+
+resource "helm_release" "oauth2_proxy" {
+  depends_on = [kubernetes_namespace.auth_namespace]
+
+  name       = "oauth2-proxy"
+  repository = "https://oauth2-proxy.github.io/manifests"
+  chart      = "oauth2-proxy"
+  version    = "7.12.17"
+  namespace  = kubernetes_namespace.auth_namespace.metadata[0].name
+  timeout    = 300
+  wait       = true
+
+  values = [
+    templatefile(
+      "${path.module}/templates/oauth2-proxy.tftpl",
+      {
+        auth0_domain                   = var.auth_auth0_domain
+        oauth2_proxy_host              = var.auth_oauth2_proxy_host
+        oauth2_proxy_cookie_domains    = var.auth_oauth2_proxy_cookie_domains
+        oauth2_proxy_whitelist_domains = var.auth_oauth2_proxy_whitelist_domains
+
+        ingress_class_name   = var.auth_ingress_class_name
+        ingress_enable_tls   = var.auth_ingress_enable_tls
+        prometheus_namespace = var.prometheus_namespace
+
+        host_alias_ip        = var.auth_host_alias_ip
+        host_alias_hostnames = var.auth_host_alias_hostnames
+      }
+    ),
+  ]
+}

--- a/stage2/auth/output.tf
+++ b/stage2/auth/output.tf
@@ -1,0 +1,8 @@
+output "auth_namespace" {
+  value = kubernetes_namespace.auth_namespace.metadata[0].name
+}
+
+output "oauth2_proxy_cookie_secret" {
+  value     = random_password.oauth2_proxy_cookie_secret.result
+  sensitive = true
+}

--- a/stage2/auth/provider.tf
+++ b/stage2/auth/provider.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.31.0"
+    }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.14.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6.2"
+    }
+  }
+}

--- a/stage2/auth/templates/oauth2-proxy.tftpl
+++ b/stage2/auth/templates/oauth2-proxy.tftpl
@@ -1,0 +1,94 @@
+# https://github.com/oauth2-proxy/manifests/blob/main/helm/oauth2-proxy/values.yaml
+
+# Oauth client configuration specifics
+config:
+  existingSecret: oauth2-proxy-cookie-secret
+
+  # Auth0 OIDC configuration
+  configFile: |-
+    # Auth0 Provider Configuration
+    provider = "oidc"
+    provider_display_name = "Auth0"
+    oidc_issuer_url = "https://${auth0_domain}/"
+    redirect_url = "https://${oauth2_proxy_host}/oauth2/callback"
+
+    code_challenge_method = "S256"
+
+    # Security Configuration
+    email_domains = ["*"]
+    cookie_secure = true
+    cookie_httponly = true
+    cookie_samesite = "lax"
+    cookie_domains = ${oauth2_proxy_cookie_domains}
+
+    # Networking Configuration
+    reverse_proxy = true
+    real_client_ip_header = "X-Real-IP"
+
+    # Features Configuration
+    skip_provider_button = true
+    pass_access_token = true
+    pass_authorization_header = true
+    set_authorization_header = true
+    set_xauthrequest = true
+
+    # Domain Whitelist
+    whitelist_domains = ${oauth2_proxy_whitelist_domains}
+
+    # Upstream Configuration
+    upstreams = ["file:///dev/null"]
+
+    # Logging
+    silence_ping_logging = true
+    request_logging = true
+
+ingress:
+  enabled: true
+  className: ${ingress_class_name}
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  labels: {}
+  hosts:
+  - ${oauth2_proxy_host}
+  path: /
+  %{ if ingress_enable_tls }
+  tls:
+    - secretName: oauth2-proxy-tls
+      hosts:
+        - ${oauth2_proxy_host}
+  %{ endif }
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 300Mi
+  requests:
+    cpu: 100m
+    memory: 300Mi
+
+
+metrics:
+  # Enable Prometheus metrics endpoint
+  enabled: true
+  # Serve Prometheus metrics on this port
+  port: 44180
+  service:
+    appProtocol: http
+  serviceMonitor:
+    # Enable Prometheus Operator ServiceMonitor
+    enabled: true
+    # Define the namespace where to deploy the ServiceMonitor resource
+    namespace: "${prometheus_namespace}"  # monitoring
+    # Prometheus Instance definition
+    prometheusInstance: default
+    # Prometheus scrape interval
+    interval: 60s
+    # Prometheus scrape timeout
+    scrapeTimeout: 30s
+
+hostAliases:
+- ip: ${host_alias_ip}
+  hostnames:
+  %{ for hostname in split(",", host_alias_hostnames) ~}
+  - "${hostname}"
+  %{ endfor ~}

--- a/stage2/auth/variables.tf
+++ b/stage2/auth/variables.tf
@@ -1,0 +1,65 @@
+variable "prometheus_namespace" {
+  description = "The namespace for the prometheus"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "auth_ingress_class_name" {
+  description = "Ingress class name for the oauth2 proxy"
+  type        = string
+  default     = "nginx"
+}
+
+variable "auth_ingress_enable_tls" {
+  description = "Enable TLS for the oauth2 proxy"
+  type        = bool
+  default     = true
+}
+
+variable "auth_oauth2_proxy_host" {
+  description = "The host for the oauth2 proxy"
+  type        = string
+  default     = "auth.chrislee.local"
+}
+
+variable "auth_oauth2_proxy_cookie_domains" {
+  description = "The domains for the oauth2 proxy cookie"
+  type        = string
+  default     = "[\".chrislee.local\"]"
+}
+
+variable "auth_oauth2_proxy_whitelist_domains" {
+  description = "The whitelist domains for the oauth2 proxy"
+  type        = string
+  default     = "[\"*.chrislee.local\"]"
+}
+
+variable "auth_auth0_domain" {
+  description = "The domain name for the auth0"
+  type        = string
+  default     = "chrislee.auth0.com"
+}
+
+variable "auth_auth0_client_id" {
+  description = "The client id for the auth0"
+  type        = string
+  default     = ""
+}
+
+variable "auth_auth0_client_secret" {
+  description = "The client secret for the auth0"
+  type        = string
+  sensitive   = true
+}
+
+variable "auth_host_alias_ip" {
+  description = "The IP address of the host alias."
+  type        = string
+  default     = ""
+}
+
+variable "auth_host_alias_hostnames" {
+  description = "The hostnames of the host alias comma separated. i.e. remote1.local,remote2.local"
+  type        = string
+  default     = ""
+}

--- a/stage2/kubecost/kubecost.tf
+++ b/stage2/kubecost/kubecost.tf
@@ -38,7 +38,8 @@ resource "helm_release" "kubecost" {
     templatefile(
       "${path.module}/templates/kubecost-values.tftpl",
       {
-        kubecost_token = var.kubecost_token
+        auth_oauth2_proxy_host = var.auth_oauth2_proxy_host
+        kubecost_token         = var.kubecost_token
 
         ingress_enable_tls = var.kubecost_ingress_enable_tls
         ingress_class_name = var.kubecost_ingress_class_name

--- a/stage2/kubecost/templates/kubecost-values.tftpl
+++ b/stage2/kubecost/templates/kubecost-values.tftpl
@@ -239,9 +239,9 @@ ingress:
   className: ${ingress_class_name}
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: ${kubecost_basic_auth_secret_name}
-    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
+    nginx.ingress.kubernetes.io/auth-url: "https://${auth_oauth2_proxy_host}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://${auth_oauth2_proxy_host}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token"
   paths: ["/"]  # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing
   pathType: ImplementationSpecific
   hosts:

--- a/stage2/kubecost/variables.tf
+++ b/stage2/kubecost/variables.tf
@@ -28,3 +28,9 @@ variable "kubecost_ingress_host" {
   type        = string
   default     = "cost.chrislee.local"
 }
+
+variable "auth_oauth2_proxy_host" {
+  description = "The host for the oauth2 proxy"
+  type        = string
+  default     = "auth.chrislee.local"
+}

--- a/stage2/logging/eck-elasticsearch-post-setup.tf
+++ b/stage2/logging/eck-elasticsearch-post-setup.tf
@@ -23,7 +23,6 @@ resource "kubernetes_config_map" "elasticsearch_setup_script" {
 }
 
 resource "kubernetes_job" "elasticsearch_post_setup" {
-  # Add data source dependency
   depends_on = [
     kubernetes_config_map.elasticsearch_setup_script,
     data.kubernetes_resource.elasticsearch,
@@ -36,6 +35,7 @@ resource "kubernetes_job" "elasticsearch_post_setup" {
   }
 
   spec {
+
     template {
       metadata {
         # Add elasticsearch version to force job recreation when elasticsearch changes

--- a/stage2/logging/eck-stack.tf
+++ b/stage2/logging/eck-stack.tf
@@ -121,10 +121,10 @@ resource "kubernetes_ingress_v1" "kibana_ingress" {
     name      = "kibana-ingress"
     namespace = kubernetes_namespace.logging.metadata[0].name
     annotations = {
-      "cert-manager.io/cluster-issuer"          = "letsencrypt-prod"
-      "nginx.ingress.kubernetes.io/auth-type"   = "basic"
-      "nginx.ingress.kubernetes.io/auth-secret" = kubernetes_secret.frontend_basic_auth.metadata[0].name
-      "nginx.ingress.kubernetes.io/auth-realm"  = "Authentication Required"
+      "cert-manager.io/cluster-issuer"                    = "letsencrypt-prod"
+      "nginx.ingress.kubernetes.io/auth-url"              = "https://${var.auth_oauth2_proxy_host}/oauth2/auth"
+      "nginx.ingress.kubernetes.io/auth-signin"           = "https://${var.auth_oauth2_proxy_host}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+      "nginx.ingress.kubernetes.io/auth-response-headers" = "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token"
     }
   }
 

--- a/stage2/logging/variables.tf
+++ b/stage2/logging/variables.tf
@@ -70,3 +70,9 @@ variable "kibana_domain" {
   type        = string
   default     = "kibana.chrislee.local"
 }
+
+variable "auth_oauth2_proxy_host" {
+  description = "The host for the oauth2 proxy"
+  type        = string
+  default     = "auth.chrislee.local"
+}

--- a/stage2/longhorn-storage/longhorn.tf
+++ b/stage2/longhorn-storage/longhorn.tf
@@ -35,8 +35,9 @@ resource "helm_release" "longhorn" {
 
   values = [
     templatefile(
-      "${path.module}/longhorn-values.tftpl",
+      "${path.module}/templates/longhorn-values.tftpl",
       {
+        auth_oauth2_proxy_host                      = var.auth_oauth2_proxy_host
         frontend_basic_auth_secret_name             = kubernetes_secret.frontend_basic_auth.metadata[0].name
         longhorn_default_settings_default_data_path = var.longhorn_default_settings_default_data_path
         longhorn_ingress_class_name                 = var.longhorn_ingress_class_name

--- a/stage2/longhorn-storage/templates/longhorn-values.tftpl
+++ b/stage2/longhorn-storage/templates/longhorn-values.tftpl
@@ -1,0 +1,58 @@
+# https://github.com/longhorn/longhorn/blob/master/chart/values.yaml
+
+persistence:
+  defaultClassReplicaCount: 1
+  reclaimPolicy: Retain
+
+preUpgradeChecker:
+  jobEnabled: true
+  upgradeVersionCheck: true
+
+csi:
+  kubeletRootDir: ~
+  attacherReplicaCount: 1
+  provisionerReplicaCount: 1
+  resizerReplicaCount: 1
+  snapshotterReplicaCount: 1
+
+defaultSettings:
+  defaultDataPath: ${longhorn_default_settings_default_data_path}
+  defaultReplicaCount: 1
+  backupCompressionMethod: "gzip"
+  snapshotMaxCount: 3
+
+ingress:
+  enabled: true
+  ingressClassName: ${longhorn_ingress_class_name}
+  host: ${longhorn_ingress_host}
+  tls: ${longhorn_ingress_enable_tls}
+  secureBackends: true
+  tlsSecret: longhorn-tls
+  path: /
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/auth-url: "https://${auth_oauth2_proxy_host}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://${auth_oauth2_proxy_host}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token"
+
+metrics:
+  serviceMonitor:
+    # -- Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components.
+    enabled: true
+    # -- Additional labels for the Prometheus ServiceMonitor resource.
+    additionalLabels:
+      release: kube-prometheus-stack
+    # -- Annotations for the Prometheus ServiceMonitor resource.
+    annotations: {}
+    # -- Interval at which Prometheus scrapes the metrics from the target.
+    interval: "30s"
+    # -- Timeout after which Prometheus considers the scrape to be failed.
+    scrapeTimeout: "10s"
+    # -- Configures the relabeling rules to apply the target's metadata labels. See the [Prometheus Operator
+    # documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for
+    # formatting details.
+    relabelings: []
+    # -- Configures the relabeling rules to apply to the samples before ingestion. See the [Prometheus Operator
+    # documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for
+    # formatting details.
+    metricRelabelings: []

--- a/stage2/longhorn-storage/variables.tf
+++ b/stage2/longhorn-storage/variables.tf
@@ -25,3 +25,9 @@ variable "longhorn_ingress_enable_tls" {
   type        = bool
   default     = true
 }
+
+variable "auth_oauth2_proxy_host" {
+  description = "The host for the oauth2 proxy"
+  type        = string
+  default     = "auth.chrislee.local"
+}

--- a/stage2/main.tf
+++ b/stage2/main.tf
@@ -17,6 +17,24 @@ module "nginx" {
   wireguard_port = var.wireguard_port
 }
 
+module "auth" {
+  depends_on = [module.nginx, module.monitoring, module.cert_manager_letsencrypt]
+  source     = "./auth"
+
+  prometheus_namespace                = module.monitoring.monitoring_namespace
+  auth_ingress_class_name             = var.auth_ingress_class_name
+  auth_ingress_enable_tls             = var.ingress_enable_tls
+  auth_oauth2_proxy_host              = var.auth_oauth2_proxy_host
+  auth_oauth2_proxy_cookie_domains    = var.auth_oauth2_proxy_cookie_domains
+  auth_oauth2_proxy_whitelist_domains = var.auth_oauth2_proxy_whitelist_domains
+  auth_auth0_domain                   = var.auth_auth0_domain
+  auth_auth0_client_id                = var.auth_auth0_client_id
+  auth_auth0_client_secret            = var.auth_auth0_client_secret
+  auth_host_alias_ip                  = var.cert_manager_host_alias_ip
+  auth_host_alias_hostnames           = var.cert_manager_host_alias_hostnames
+}
+
+
 module "cert_manager_letsencrypt" {
   depends_on = [module.nginx]
   source     = "./cert-manager-letsencrypt"
@@ -37,6 +55,7 @@ module "longhorn_storage" {
   longhorn_ingress_class_name                 = var.longhorn_ingress_class_name
   longhorn_ingress_host                       = var.longhorn_ingress_host
   longhorn_ingress_enable_tls                 = var.ingress_enable_tls
+  auth_oauth2_proxy_host                      = var.auth_oauth2_proxy_host
 }
 
 module "minio_object_storage" {
@@ -54,6 +73,7 @@ module "minio_object_storage" {
   minio_tenant_ingress_api_host         = var.minio_tenant_ingress_api_host
   minio_tenant_ingress_console_host     = var.minio_tenant_ingress_console_host
   minio_tenant_ingress_enable_tls       = var.ingress_enable_tls
+  auth_oauth2_proxy_host                = var.auth_oauth2_proxy_host
 }
 
 module "gitlab_platform" {
@@ -110,6 +130,7 @@ module "logging" {
   kibana_ingress_enable_tls        = var.ingress_enable_tls
   kibana_domain                    = var.kibana_domain
   nginx_frontend_basic_auth_base64 = var.nginx_frontend_basic_auth_base64
+  auth_oauth2_proxy_host           = var.auth_oauth2_proxy_host
 }
 module "monitoring" {
   depends_on = [module.cert_manager_letsencrypt, module.logging]
@@ -137,6 +158,8 @@ module "monitoring" {
   elastalert2_elasticsearch_port     = module.logging.elasticsearch_port
   elastalert2_elasticsearch_username = module.logging.elasticsearch_username
   elastalert2_elasticsearch_password = module.logging.elasticsearch_password
+
+  auth_oauth2_proxy_host = var.auth_oauth2_proxy_host
 }
 
 
@@ -149,6 +172,7 @@ module "kubecost" {
   kubecost_ingress_host            = var.kubecost_ingress_host
   kubecost_ingress_enable_tls      = var.ingress_enable_tls
   kubecost_ingress_class_name      = var.kubecost_ingress_class_name
+  auth_oauth2_proxy_host           = var.auth_oauth2_proxy_host
 }
 
 module "vpn" {
@@ -179,4 +203,6 @@ module "argocd" {
   argocd_ingress_class_name     = var.argocd_ingress_class_name
   argocd_ssh_known_hosts_base64 = var.argocd_ssh_known_hosts_base64
   argocd_config_repositories    = jsondecode(var.argocd_config_repositories_json_encoded)
+
+  auth_oauth2_proxy_host = var.auth_oauth2_proxy_host
 }

--- a/stage2/main.tf
+++ b/stage2/main.tf
@@ -122,7 +122,7 @@ module "monitoring" {
   prometheus_ingress_enable_tls    = var.ingress_enable_tls
 
   prometheus_prometheus_domain     = var.prometheus_prometheus_domain
-  prometehus_grafana_storage_class = var.prometheus_persistence_storage_class_name
+  prometheus_grafana_storage_class = var.prometheus_persistence_storage_class_name
   prometheus_persistence_size      = var.prometheus_persistence_size
 
   prometheus_alertmanager_slack_channel     = var.prometheus_alertmanager_slack_channel

--- a/stage2/minio-object-storage/minio-tenant-values.tftpl
+++ b/stage2/minio-object-storage/minio-tenant-values.tftpl
@@ -114,9 +114,9 @@ ingress:
     labels: { }
     annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
-      nginx.ingress.kubernetes.io/auth-type: basic
-      nginx.ingress.kubernetes.io/auth-secret: ${frontend_basic_auth_secret_name}
-      nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
+      nginx.ingress.kubernetes.io/auth-url: "https://${auth_oauth2_proxy_host}/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-signin: "https://${auth_oauth2_proxy_host}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+      nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token"
     %{ if tenant_ingress_enable_tls }
     tls:
       - hosts: ["${tenant_ingress_console_host}"]

--- a/stage2/minio-object-storage/minio.tf
+++ b/stage2/minio-object-storage/minio.tf
@@ -167,6 +167,7 @@ resource "helm_release" "minio_tenant" {
         tenant_ingress_api_host         = var.minio_tenant_ingress_api_host
         tenant_ingress_console_host     = var.minio_tenant_ingress_console_host
         tenant_ingress_enable_tls       = var.minio_tenant_ingress_enable_tls
+        auth_oauth2_proxy_host          = var.auth_oauth2_proxy_host
       }
     ),
   ]

--- a/stage2/minio-object-storage/variables.tf
+++ b/stage2/minio-object-storage/variables.tf
@@ -62,3 +62,9 @@ variable "minio_tenant_ingress_enable_tls" {
   type        = bool
   default     = true
 }
+
+variable "auth_oauth2_proxy_host" {
+  description = "The host for the oauth2 proxy"
+  type        = string
+  default     = "auth.chrislee.local"
+}

--- a/stage2/monitoring/prometheus-stack.tf
+++ b/stage2/monitoring/prometheus-stack.tf
@@ -66,7 +66,7 @@ resource "helm_release" "prometheus_operator" {
         alertmanager_domain             = var.prometheus_alertmanager_domain
         grafana_domain                  = var.prometheus_grafana_domain
         grafana_admin_password          = random_password.grafana_admin_password.result
-        grafana_storage_class           = var.prometehus_grafana_storage_class
+        grafana_storage_class           = var.prometheus_grafana_storage_class
 
         ingress_class_name = var.prometheus_ingress_class_name
         ingress_enable_tls = var.prometheus_ingress_enable_tls

--- a/stage2/monitoring/prometheus-stack.tf
+++ b/stage2/monitoring/prometheus-stack.tf
@@ -40,8 +40,6 @@ resource "kubectl_manifest" "prometheus_rules" {
   )
 }
 
-
-
 resource "helm_release" "prometheus_operator" {
   depends_on = [
     kubernetes_namespace.monitoring_namespace,
@@ -82,6 +80,8 @@ resource "helm_release" "prometheus_operator" {
         minio_job_node_bearer_token     = var.prometheus_minio_job_node_bearer_token
         minio_job_bucket_bearer_token   = var.prometheus_minio_job_bucket_bearer_token
         minio_job_resource_bearer_token = var.prometheus_minio_job_resource_bearer_token
+
+        auth_oauth2_proxy_host = var.auth_oauth2_proxy_host
       }
     )
   ]

--- a/stage2/monitoring/templates/prometheus-stack-values.tftpl
+++ b/stage2/monitoring/templates/prometheus-stack-values.tftpl
@@ -110,9 +110,9 @@ alertmanager:
     ingressClassName: ${ingress_class_name}
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-prod
-      nginx.ingress.kubernetes.io/auth-type: basic
-      nginx.ingress.kubernetes.io/auth-secret: ${frontend_basic_auth_secret_name}
-      nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
+      nginx.ingress.kubernetes.io/auth-url: "https://${auth_oauth2_proxy_host}/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-signin: "https://${auth_oauth2_proxy_host}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+      nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token"
     labels: {}
     hosts:
       - ${alertmanager_domain}
@@ -175,9 +175,9 @@ grafana:
     ingressClassName: ${ingress_class_name}
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-prod
-      nginx.ingress.kubernetes.io/auth-type: basic
-      nginx.ingress.kubernetes.io/auth-secret: ${frontend_basic_auth_secret_name}
-      nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
+      nginx.ingress.kubernetes.io/auth-url: "https://${auth_oauth2_proxy_host}/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-signin: "https://${auth_oauth2_proxy_host}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+      nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token"
     labels: {}
     hosts:
       - ${grafana_domain}
@@ -274,9 +274,9 @@ prometheus:
     ingressClassName: ${ingress_class_name}
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-prod
-      nginx.ingress.kubernetes.io/auth-type: basic
-      nginx.ingress.kubernetes.io/auth-secret: ${frontend_basic_auth_secret_name}
-      nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
+      nginx.ingress.kubernetes.io/auth-url: "https://${auth_oauth2_proxy_host}/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-signin: "https://${auth_oauth2_proxy_host}/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+      nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token"
     labels: {}
     hosts:
       - ${prometheus_domain}

--- a/stage2/monitoring/variables.tf
+++ b/stage2/monitoring/variables.tf
@@ -109,3 +109,9 @@ variable "elastalert2_elasticsearch_password" {
   type        = string
   sensitive   = true
 }
+
+variable "auth_oauth2_proxy_host" {
+  description = "The host for the oauth2 proxy"
+  type        = string
+  default     = "auth.chrislee.local"
+}

--- a/stage2/monitoring/variables.tf
+++ b/stage2/monitoring/variables.tf
@@ -16,7 +16,7 @@ variable "prometheus_grafana_domain" {
   default     = "grafana.chrislee.local"
 }
 
-variable "prometehus_grafana_storage_class" {
+variable "prometheus_grafana_storage_class" {
   description = "The storage class for the grafana"
   type        = string
   default     = "longhorn"

--- a/stage2/variables.tf
+++ b/stage2/variables.tf
@@ -340,7 +340,7 @@ variable "elasticsearch_resource_request_cpu" {
 variable "elasticsearch_resource_limit_memory" {
   description = "Memory limit for Elasticsearch"
   type        = string
-  default     = "3Gi"
+  default     = "2Gi"
 }
 
 variable "elasticsearch_resource_limit_cpu" {
@@ -480,4 +480,46 @@ variable "argocd_config_repositories_json_encoded" {
   description = "The repositories for the argocd - json encoded"
   type        = string
   default     = "[]"
+}
+
+variable "auth_ingress_class_name" {
+  description = "Ingress class name for the oauth2 proxy"
+  type        = string
+  default     = "nginx"
+}
+
+variable "auth_oauth2_proxy_host" {
+  description = "The host for the oauth2 proxy"
+  type        = string
+  default     = "auth.chrislee.local"
+}
+
+variable "auth_oauth2_proxy_cookie_domains" {
+  description = "The domains for the oauth2 proxy cookie"
+  type        = string
+  default     = "[\".chrislee.local\"]"
+}
+
+variable "auth_oauth2_proxy_whitelist_domains" {
+  description = "The whitelist domains for the oauth2 proxy"
+  type        = string
+  default     = "[\"*.chrislee.local\"]"
+}
+
+variable "auth_auth0_domain" {
+  description = "The domain name for the auth0"
+  type        = string
+  default     = "chrislee.auth0.com"
+}
+
+variable "auth_auth0_client_id" {
+  description = "The client id for the auth0"
+  type        = string
+  default     = ""
+}
+
+variable "auth_auth0_client_secret" {
+  description = "The client secret for the auth0"
+  type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
In this PR, I've added `oauth2-proxy` integrated with `auth0`.

- Replaced Basic Auth to `oauth2-proxy` with Auth0
- Fixed `coredns-custom` patching
