### PR TITLE
fix: updated Gitlab autovacuum config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,6 +43,7 @@
     "minio",
     "minitunnel",
     "multipathd",
+    "naptime",
     "nerdctl",
     "omniauth",
     "pipefail",
@@ -56,7 +57,8 @@
     "tflint",
     "tftpl",
     "traefik",
-    "trivy"
+    "trivy",
+    "venv"
   ],
   "yaml.format.enable": true,
   "files.associations": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,12 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN set -eux; \
   \
   apk add --no-cache \
-  ca-certificates=20241121-r1 \
+  ca-certificates=20250619-r0 \
   curl=8.12.1-r0 \
   bash=5.2.26-r0 \
   jq=1.7.1-r0 \
-  bind-tools=9.18.37-r0 \
-  git=2.45.3-r0 \
+  bind-tools=9.18.39-r0 \
+  git=2.45.4-r0 \
   && \
   \
   # Install kubectl - https://dl.k8s.io/release/v1.30.2/bin/linux/arm64/kubectl

--- a/stage2/gitlab-platform/templates/gitlab-values.tftpl
+++ b/stage2/gitlab-platform/templates/gitlab-values.tftpl
@@ -709,9 +709,17 @@ postgresql:
       enabled: true
       size: ${postgresql_primary_persistence_size}
     extendedConfiguration: |
+      # Autovacuum settings
       autovacuum = on
-      autovacuum_analyze_scale_factor = 0.05
-      autovacuum_analyze_threshold = 10
+      autovacuum_max_workers = 6
+      autovacuum_naptime = 1min
+      autovacuum_vacuum_threshold = 50
+      autovacuum_analyze_threshold = 50
+      autovacuum_vacuum_scale_factor = 0.01
+      autovacuum_analyze_scale_factor = 0.1
+      autovacuum_vacuum_cost_delay = 20ms
+      autovacuum_vacuum_cost_limit = 3000
+      log_autovacuum_min_duration = 0
   metrics:
     enabled: true
     service:


### PR DESCRIPTION
In this PR, I've setting auto vacuum setting for Gitlab.

I still get the alert like the below:

```
pg_stat_user_tables_last_autoanalyze{container="metrics", datname="gitlabhq_production", endpoint="http-metrics", instance="10.0.0.160:9187", job="gitlab-postgresql-metrics", namespace="gitlab", pod="gitlab-postgresql-0", relname="ci_deleted_objects", schemaname="public", service="gitlab-postgresql-metrics"}	
```

I've configured table-specific autovacuum settings. I removed that first from all tables using the following commands.

```
SELECT 'ALTER TABLE ' || schemaname || '.' || relname || 
       ' RESET (autovacuum_analyze_threshold, autovacuum_analyze_scale_factor);'
FROM pg_stat_user_tables 
WHERE schemaname IN ('gitlab_partitions_dynamic', 'gitlab_partitions_static', 'public');
```

And then `terraform apply`. It's resolved now, but I think it's because postgres is restarted.

```
2025-08-23 12:08:14.300 GMT [369] LOG:  automatic vacuum of table "gitlabhq_production.pg_catalog.pg_class": index scans: 1                       
    pages: 0 removed, 287 remain, 253 scanned (88.15% of total)                                                                                   
    tuples: 3 removed, 9798 remain, 0 are dead but not yet removable                                                                              
    removable cutoff: 103474, which was 0 XIDs old when operation ended                                                                           
    frozen: 0 pages from table (0.00% of total) had 0 tuples frozen                                                                               
    index scan needed: 101 pages from table (35.19% of total) had 219 dead item identifiers removed                                               
    index "pg_class_oid_index": pages: 33 in total, 0 newly deleted, 0 currently deleted, 0 reusable                                              
    index "pg_class_relname_nsp_index": pages: 127 in total, 0 newly deleted, 1 currently deleted, 1 reusable                                     
    index "pg_class_tblspc_relfilenode_index": pages: 38 in total, 0 newly deleted, 0 currently deleted, 0 reusable                               
    avg read rate: 10.497 MB/s, avg write rate: 0.772 MB/s                                                                                        
    buffer usage: 791 hits, 68 misses, 5 dirtied                                                                                                  
    WAL usage: 375 records, 4 full page images, 48099 bytes                                                                                       
    system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.05 s                                                                              
2025-08-23 12:08:14.382 GMT [369] LOG:  automatic analyze of table "gitlabhq_production.pg_catalog.pg_class"                                      
    avg read rate: 0.762 MB/s, avg write rate: 2.954 MB/s                                                                                         
    buffer usage: 1519 hits, 8 misses, 31 dirtied                                                                                                 
    system usage: CPU: user: 0.03 s, system: 0.00 s, elapsed: 0.08 s
```

Continue monitoring.