### PR TITLE
fix: ElasticSearch ILM policy

### DIFF
--- a/stage2/logging/scripts/elasticsearch-post-setup.sh
+++ b/stage2/logging/scripts/elasticsearch-post-setup.sh
@@ -60,34 +60,18 @@ curl -k -X PUT \
             "actions": {
               "rollover": {
                 "max_primary_shard_size": "10gb",
-                "max_age": "12h",
-                "max_docs": 500000
+                "max_age": "24h",
+                "max_docs": 1000000
               },
               "set_priority": {
                 "priority": 100
               }
             }
           },
-          "warm": {
-            "min_age": "6h",
-            "actions": {
-              "set_priority": {
-                "priority": 50
-              },
-              "shrink": {
-                "number_of_shards": 1
-              },
-              "forcemerge": {
-                "max_num_segments": 1
-              }
-            }
-          },
           "delete": {
-            "min_age": "12h",
+            "min_age": "0ms",
             "actions": {
-              "delete": {
-                "delete_searchable_snapshot": true
-              }
+              "delete": {}
             }
           }
         }

--- a/stage2/logging/templates/eck/filebeat-ilm-policy.json
+++ b/stage2/logging/templates/eck/filebeat-ilm-policy.json
@@ -6,34 +6,18 @@
         "actions": {
           "rollover": {
             "max_primary_shard_size": "10gb",
-            "max_age": "12h",
-            "max_docs": 500000
+            "max_age": "24h",
+            "max_docs": 1000000
           },
           "set_priority": {
             "priority": 100
           }
         }
       },
-      "warm": {
-        "min_age": "6h",
-        "actions": {
-          "set_priority": {
-            "priority": 50
-          },
-          "shrink": {
-            "number_of_shards": 1
-          },
-          "forcemerge": {
-            "max_num_segments": 1
-          }
-        }
-      },
       "delete": {
-        "min_age": "12h",
+        "min_age": "0ms",
         "actions": {
-          "delete": {
-            "delete_searchable_snapshot": true
-          }
+          "delete": {}
         }
       }
     }


### PR DESCRIPTION
Back then, due to the disk usage pressure, I made to store indexes only 12 hours, but I found

```
curl -X GET "localhost:9200/_cat/indices?v&s=index"
health status index                                                              uuid                   pri rep docs.count docs.deleted store.size pri.store.size dataset.size
red    open   .ds-filebeat-custom-2025.06.20-000001                              U-tMCEJIR02A0U28DpgJUw   1   1
red    open   .ds-filebeat-custom-2025.06.21-000002                              TkkIg2lrSHG_KgHRALFqHQ   1   1
...
```

It was still storing old indexes.

Apparently, it cannot leave hot phase because only hot-tier nodes.
After ILM tries to migrate the index to a warm-tier node, ILM stops at the hot and the delete phase is never evaluated.

So I updated ILM to be hot -> delete immediately.

Related errors:

```
{"error":{"root_cause":[{"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<http_request>] would be [1029509368/981.8mb], which is larger than the limit of [1020054732/972.7mb], real usage: [1029509368/981.8mb], new bytes reserved: [0/0b], usages [fielddata=0/0b, request=0/0b, inflight_requests=0/0b, model_inference=0/0b, eql_sequence=0/0b]","bytes_wanted":1029509368,"bytes_limit":1020054732,"durability":"TRANSIENT"}],"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<http_request>] would be [1029509368/981.8mb], which is larger than the limit of [1020054732/972.7mb], real usage: [1029509368/981.8mb], new bytes reserved: [0/0b], usages [fielddata=0/0b, request=0/0b, inflight_requests=0/0b, model_inference=0/0b, eql_sequence=0/0b]","bytes_wanted":1029509368,"bytes_limit":1020054732,"durability":"TRANSIENT"},"status":429}
```
