### PR TITLE
refactor(infra): Ansible idempotency, GitLab chart cleanup, and TF deprecations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,3 +87,10 @@ repos:
     hooks:
       - id: gitleaks
         stages: [pre-commit]
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        # -x follows `source` directives across files
+        args: ["-x"]

--- a/stage1/roles/host_setup/tasks/disable-swap.yml
+++ b/stage1/roles/host_setup/tasks/disable-swap.yml
@@ -1,8 +1,13 @@
 ---
+- name: Check active swap
+  ansible.builtin.command: swapon --show
+  register: host_setup_active_swap
+  changed_when: false
+
 - name: Disable swap
   ansible.builtin.command: swapoff -a
-  register: host_setup_swapoff
-  changed_when: host_setup_swapoff.rc == 0
+  when: host_setup_active_swap.stdout | length > 0
+  changed_when: true
 
 - name: Remove swap entry from /etc/fstab
   ansible.builtin.replace:

--- a/stage1/roles/k3s_server/tasks/main.yml
+++ b/stage1/roles/k3s_server/tasks/main.yml
@@ -32,7 +32,9 @@
       environment:
         INSTALL_K3S_SKIP_START: "true"
         INSTALL_K3S_VERSION: "{{ k3s_version }}"
-      changed_when: true
+      changed_when:
+        - k3s_server_installed_k3s_version is not defined
+          or k3s_server_installed_k3s_version is version(k3s_version, '<')
 
 - name: Add K3s autocomplete to user bashrc
   ansible.builtin.lineinfile:

--- a/stage1/roles/kubeadm_pre_setup/tasks/bootstrap-node.yml
+++ b/stage1/roles/kubeadm_pre_setup/tasks/bootstrap-node.yml
@@ -1,10 +1,19 @@
 ---
-- name: Update and upgrade apt packages
+- name: Refresh apt cache if older than 1 hour
   ansible.builtin.apt:
     update_cache: true
-    upgrade: true
+    cache_valid_time: 3600
+
+# Patches the host on every default playbook run because unattended-upgrades is
+# turned off by the `Disable automatic updates` task later in this file. Use
+# `--skip-tags system_upgrade` to skip the apt safe-upgrade plus the bundled
+# autoclean/autoremove; other mutating tasks in this role still run.
+- name: Upgrade apt packages
+  ansible.builtin.apt:
+    upgrade: safe
     autoclean: true
     autoremove: true
+  tags: [system_upgrade]
 
 - name: Define list of packages
   ansible.builtin.set_fact:

--- a/stage1/roles/kubeadm_server/handlers/main.yml
+++ b/stage1/roles/kubeadm_server/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart containerd
+  ansible.builtin.service:
+    name: containerd
+    state: restarted

--- a/stage1/roles/kubeadm_server/tasks/configure-containerd.yml
+++ b/stage1/roles/kubeadm_server/tasks/configure-containerd.yml
@@ -74,20 +74,21 @@
       ansible.builtin.file:
         path: /etc/containerd/
         state: directory
+        mode: "0755"
+
+    - name: Generate default containerd config
+      ansible.builtin.command: containerd config default
+      register: kubeadm_server_containerd_default_config
+      changed_when: false
+
+    - name: Write containerd config.toml with SystemdCgroup enabled
+      ansible.builtin.copy:
+        content: "{{ kubeadm_server_containerd_default_config.stdout
+                     | replace('SystemdCgroup = false', 'SystemdCgroup = true') }}"
+        dest: /etc/containerd/config.toml
         mode: "0644"
+      notify: Restart containerd
 
-    - name: Generate default config for containerd and save it to config.toml file.
-      ansible.builtin.shell: "containerd config default > /etc/containerd/config.toml"
-      register: kubeadm_server_containerd_toml
-      changed_when: kubeadm_server_containerd_toml.rc == 0
-
-    - name: Update the value of SystemdCgroup in the config.toml file.
-      ansible.builtin.replace:
-        path: /etc/containerd/config.toml
-        regexp: "SystemdCgroup = false"
-        replace: "SystemdCgroup = true"
-
-    - name: Restart containerd service
-      ansible.builtin.service:
-        name: containerd
-        state: restarted
+    # Flush so containerd restart completes before kubeadm init runs.
+    - name: Flush handlers
+      ansible.builtin.meta: flush_handlers

--- a/stage1/roles/kubeadm_server/tasks/download-kubeconfig.yml
+++ b/stage1/roles/kubeadm_server/tasks/download-kubeconfig.yml
@@ -2,5 +2,5 @@
 - name: Fetch .kube/config file from remote instance
   ansible.builtin.fetch:
     src: "{{ ansible_env.HOME }}/.kube/config"
-    dest: ~/.kube/config.new
+    dest: ~/.kube/config
     flat: true

--- a/stage1/roles/kubeadm_server/tasks/initialise-kubeadm.yml
+++ b/stage1/roles/kubeadm_server/tasks/initialise-kubeadm.yml
@@ -70,7 +70,9 @@
         kubectl apply -f -
       args:
         executable: /bin/bash
-      changed_when: false
+      register: kubeadm_server_kubeadm_config_update
+      # kubectl apply emits "...configured" on mutation, "...unchanged" on no-op.
+      changed_when: "'configured' in kubeadm_server_kubeadm_config_update.stdout"
     - name: Update kube-proxy configmap to bind metrics endpoint to 0.0.0.0
       ansible.builtin.shell: |
         set -o pipefail && \
@@ -81,7 +83,9 @@
         kubectl apply -f -
       args:
         executable: /bin/bash
-      changed_when: false
+      register: kubeadm_server_kube_proxy_update
+      # kubectl apply emits "...configured" on mutation, "...unchanged" on no-op.
+      changed_when: "'configured' in kubeadm_server_kube_proxy_update.stdout"
     - name: Restart kubelet service
       ansible.builtin.systemd:
         name: kubelet

--- a/stage1/roles/localhost_post_setup/tasks/rename-kubeconfig.yml
+++ b/stage1/roles/localhost_post_setup/tasks/rename-kubeconfig.yml
@@ -1,9 +1,11 @@
 ---
-- name: Rename ~/.kube/config.new to ~/.kube/config locally
-  ansible.builtin.command:
-    cmd: mv ~/.kube/config.new ~/.kube/config
-  register: localhost_post_setup_mv_output
-  changed_when: localhost_post_setup_mv_output.rc == 0
+# Kubeconfig is now fetched directly to ~/.kube/config (see kubeadm_server
+# download-kubeconfig.yml). This task removes any orphan .new file left by the
+# previous fetch-then-rename pattern so re-runs stay clean.
+- name: Remove stale ~/.kube/config.new from prior fetch-then-rename runs
+  ansible.builtin.file:
+    path: ~/.kube/config.new
+    state: absent
 
 - name: Use kube context to the cluster
   ansible.builtin.shell: kubectl config use-context $(kubectl config get-contexts -o name)

--- a/stage2/gitlab-platform/README.md
+++ b/stage2/gitlab-platform/README.md
@@ -125,7 +125,6 @@ sequenceDiagram
 
 | Name | Description | Default |
 |------|-------------|---------|
-| `host_machine_architecture` | Architecture (amd64/arm64) | `amd64` |
 | `gitlab_global_hosts_domain` | Base domain for GitLab | `chrislee.local` |
 | `gitlab_global_hosts_host_suffix` | Subdomain suffix | `""` |
 | `gitlab_global_hosts_https` | Use HTTPS | `true` |

--- a/stage2/gitlab-platform/gitlab-secrets.tf
+++ b/stage2/gitlab-platform/gitlab-secrets.tf
@@ -140,7 +140,14 @@ resource "kubernetes_secret_v1" "rails_secret" {
   }
 
   data = {
-    "secrets.yml" = templatefile(
+    # chomp() strips the template's trailing newline so the rendered string
+    # matches what the gitlab-shared-secrets pre-upgrade hook writes back via
+    # `kubectl apply` with stringData |- (which strips trailing newlines).
+    # Without this, the secret reports a perpetual data diff on every plan.
+    # Byte-format and field order verified against gitlab chart 9.11.3
+    # (charts/shared-secrets/templates/_generate_secrets.sh.tpl). Re-verify
+    # if the chart version in gitlab.tf is bumped.
+    "secrets.yml" = chomp(templatefile(
       "${path.module}/templates/rails-secrets.tftpl",
       {
         production_secret_key_base                              = random_password.rails_secret_key_base.result,
@@ -152,7 +159,7 @@ resource "kubernetes_secret_v1" "rails_secret" {
         production_active_record_encryption_key_derivation_salt = random_password.active_record_encryption_key_derivation_salt.result,
         production_openid_connect_signing_key                   = indent(4, tls_private_key.openid_connect_signing_key.private_key_pem_pkcs8),
       }
-    )
+    ))
   }
 
   lifecycle {

--- a/stage2/gitlab-platform/gitlab.tf
+++ b/stage2/gitlab-platform/gitlab.tf
@@ -44,9 +44,6 @@ resource "helm_release" "gitlab" {
     templatefile(
       "${path.module}/templates/gitlab-values.tftpl",
       {
-        # Workaround - https://gitlab.com/groups/gitlab-org/-/epics/10938
-        platform_image_tag = var.host_machine_architecture == "arm64" ? "16-5-arm64" : "master"
-
         global_hosts_domain      = var.gitlab_global_hosts_domain
         global_hosts_host_suffix = var.gitlab_global_hosts_host_suffix
         global_hosts_https       = var.gitlab_global_hosts_https

--- a/stage2/gitlab-platform/templates/gitlab-values.tftpl
+++ b/stage2/gitlab-platform/templates/gitlab-values.tftpl
@@ -326,26 +326,15 @@ global:
     workerTimeout: 60
 
   ## https://docs.gitlab.com/charts/charts/globals#custom-certificate-authorities
-  # configuration of certificates container & custom CA injection
   certificates:
-    image:
-      repository: registry.gitlab.com/gitlab-org/build/cng/certificates
-      tag: ${platform_image_tag}
     customCAs: []
 
   ## kubectl image used by hooks to carry out specific jobs
   kubectl:
-    image:
-      repository: registry.gitlab.com/gitlab-org/build/cng/kubectl
-      tag: ${platform_image_tag}
     securityContext:
       # in most base images, this is `nobody:nogroup`
       runAsUser: 65534
       fsGroup: 65534
-  gitlabBase:
-    image:
-      repository: registry.gitlab.com/gitlab-org/build/cng/gitlab-base
-      tag: ${platform_image_tag}
 
   ## https://docs.gitlab.com/charts/charts/globals#service-accounts
   serviceAccount:
@@ -753,9 +742,6 @@ shared-secrets:
   rbac:
     create: true
   selfsign:
-    image:
-      repository: registry.gitlab.com/gitlab-org/build/cng/cfssl-self-sign
-      tag: ${platform_image_tag}
     keyAlgorithm: "rsa"
     keySize: "4096"
     expiry: "3650d"

--- a/stage2/gitlab-platform/templates/rails-secrets.tftpl
+++ b/stage2/gitlab-platform/templates/rails-secrets.tftpl
@@ -3,8 +3,10 @@ production:
   otp_key_base: ${production_otp_key_base}
   db_key_base: ${production_db_key_base}
   encrypted_settings_key_base: ${production_encrypted_settings_key_base}
-  active_record_encryption_primary_key: ${production_active_record_encryption_primary_key}
-  active_record_encryption_deterministic_key: ${production_active_record_encryption_deterministic_key}
-  active_record_encryption_key_derivation_salt: ${production_active_record_encryption_key_derivation_salt}
   openid_connect_signing_key: |
     ${production_openid_connect_signing_key}
+  active_record_encryption_primary_key:
+    ${production_active_record_encryption_primary_key}
+  active_record_encryption_deterministic_key:
+    ${production_active_record_encryption_deterministic_key}
+  active_record_encryption_key_derivation_salt: ${production_active_record_encryption_key_derivation_salt}

--- a/stage2/gitlab-platform/variables.tf
+++ b/stage2/gitlab-platform/variables.tf
@@ -1,10 +1,4 @@
 ## https://docs.gitlab.com/charts/charts/globals#configure-host-settings
-variable "host_machine_architecture" {
-  description = "The architecture of the host machine. i.e. amd64, arm64"
-  type        = string
-  default     = "amd64"
-}
-
 variable "gitlab_global_hosts_domain" {
   description = "The base domain. GitLab and Registry will be exposed on the subdomain of this setting. This defaults to example.com, but is not used for hosts that have their name property configured. See the gitlab.name, minio.name, and registry.name sections below."
   type        = string

--- a/stage2/longhorn-storage/longhorn-crds.tf
+++ b/stage2/longhorn-storage/longhorn-crds.tf
@@ -17,5 +17,5 @@ data "http" "longhorn_crd" {
 resource "kubectl_manifest" "longhorn_crd" {
   count = length(local.longhorn_crds)
 
-  yaml_body = data.http.longhorn_crd[count.index].body
+  yaml_body = data.http.longhorn_crd[count.index].response_body
 }

--- a/stage2/main.tf
+++ b/stage2/main.tf
@@ -83,8 +83,6 @@ module "gitlab_platform" {
   depends_on = [module.minio_object_storage]
   source     = "./gitlab-platform"
 
-  host_machine_architecture = var.host_machine_architecture
-
   gitlab_global_hosts_domain       = var.gitlab_global_hosts_domain
   gitlab_global_hosts_host_suffix  = var.gitlab_global_hosts_host_suffix
   gitlab_global_hosts_external_ip  = var.gitlab_global_hosts_external_ip

--- a/stage2/variables.tf
+++ b/stage2/variables.tf
@@ -21,9 +21,17 @@ variable "host_machine_architecture" {
 }
 
 variable "kubernetes_override_domains" {
-  description = "The list of domains to be added to the CoreDNS configuration. Space delimiter. i.e. gitlab.chrislee.local registry.chrislee.local minio.chrislee.local"
+  description = "Space-delimited list of domains added to the CoreDNS configuration. Each entry must be a lowercase FQDN. Example: \"gitlab.chrislee.local registry.chrislee.local minio.chrislee.local\""
   type        = string
   default     = "gitlab.chrislee.local registry.chrislee.local minio.chrislee.local"
+
+  validation {
+    condition = alltrue([
+      for d in split(" ", var.kubernetes_override_domains) :
+      can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", d))
+    ])
+    error_message = "kubernetes_override_domains must be a non-empty, single-space-delimited list of lowercase FQDNs (e.g., \"gitlab.chrislee.local registry.chrislee.local\"). No leading/trailing/multiple spaces, no uppercase, no empty entries."
+  }
 }
 
 variable "kubernetes_override_ip" {


### PR DESCRIPTION
## Summary

Bundles a set of low-risk infrastructure fixes that have been investigated and validated individually:

- Ansible roles return real `changed` state across re-runs (host_setup, k3s_server, kubeadm_pre_setup, kubeadm_server, localhost_post_setup).
- `gitlab-platform`: remove the obsolete ARM64 image-tag workaround now that chart 9.11.3 ships multi-arch images, and stop perpetual `rails-secret` Terraform drift via `chomp()` + key reordering aligned with the chart's `_generate_secrets.sh.tpl`.
- `longhorn-storage`: migrate `data.http.body` → `response_body` (hashicorp/http v3 deprecation).
- Add `shellcheck-py` pre-commit hook and a Terraform validation regex on `kubernetes_override_domains`.

### Before

```mermaid
flowchart LR
    A["Ansible run"]:::warn --> B["disable-swap<br/>swapoff -a<br/>always changed"]:::warn
    A --> C["k3s_server<br/>changed_when: true<br/>always changed"]:::warn
    A --> D["configure-containerd<br/>shell pipe + replace<br/>flip-flop config.toml"]:::warn
    A --> E["download-kubeconfig<br/>fetch to .new + mv<br/>always changed"]:::warn
    F["terraform plan"]:::warn --> G["rails-secret<br/>perpetual data diff"]:::warn
    F --> H["longhorn-crds<br/>data.http.body deprecated"]:::warn
    F --> I["gitlab-values<br/>ARM64 image overrides<br/>platform_image_tag"]:::warn
    classDef warn fill:#c0392b,color:#ffffff
```

### After

```mermaid
flowchart LR
    A["Ansible run"]:::ok --> B["disable-swap<br/>guarded by swapon --show"]:::ok
    A --> C["k3s_server<br/>changed_when: version-aware"]:::ok
    A --> D["configure-containerd<br/>command + copy + handler<br/>flush_handlers"]:::ok
    A --> E["download-kubeconfig<br/>fetch direct to ~/.kube/config"]:::ok
    F["terraform plan"]:::ok --> G["rails-secret<br/>chomp + reordered keys<br/>byte-identical"]:::ok
    F --> H["longhorn-crds<br/>response_body"]:::ok
    F --> I["gitlab-values<br/>chart defaults<br/>workaround removed"]:::ok
    classDef ok fill:#1e8449,color:#ffffff
```

## Changes

**Pre-commit / tooling**
- `.pre-commit-config.yaml`: add `shellcheck-py v0.11.0.1` with `args: ["-x"]`.

**Ansible idempotency (stage1)**
- `host_setup/tasks/disable-swap.yml`: probe with `swapon --show` and gate `swapoff -a` on non-empty stdout.
- `k3s_server/tasks/main.yml`: replace blanket `changed_when: true` with version-aware guard (`installed < target`).
- `kubeadm_pre_setup/tasks/bootstrap-node.yml`: split apt cache refresh from `upgrade: safe`; tag the upgrade `system_upgrade` so `--skip-tags system_upgrade` skips the apt safe-upgrade plus autoclean/autoremove.
- `kubeadm_server/tasks/configure-containerd.yml`: `0644 → 0755` on `/etc/containerd/`; replace shell pipe with `command: containerd config default` (`changed_when: false`) feeding `ansible.builtin.copy` whose content uses `replace('SystemdCgroup = false', 'SystemdCgroup = true')`; restart via `notify: Restart containerd` plus `meta: flush_handlers`.
- `kubeadm_server/handlers/main.yml` (new): `Restart containerd` handler.
- `kubeadm_server/tasks/download-kubeconfig.yml`: fetch directly to `~/.kube/config` (drop `.new` staging).
- `kubeadm_server/tasks/initialise-kubeadm.yml`: detect real changes via `'configured' in stdout` for both `kubectl apply` blocks instead of `changed_when: false`.
- `localhost_post_setup/tasks/rename-kubeconfig.yml`: replace `mv config.new config` shell with `file: state=absent` cleanup of any orphan `~/.kube/config.new`.

**GitLab platform (stage2/gitlab-platform) — chart 9.11.3 cleanup + rails-secret drift fix**
- `gitlab.tf` + `templates/gitlab-values.tftpl`: drop the ARM64 `platform_image_tag` workaround; remove four `${platform_image_tag}` image overrides (`global.certificates.image`, `global.kubectl.image`, `global.gitlabBase.image`, `shared-secrets.selfsign.image`); fall back to chart defaults.
- `variables.tf` + `README.md`: remove `host_machine_architecture` input.
- `gitlab-secrets.tf`: wrap `templatefile(...)` in `chomp(...)` to match the chart's `kubectl apply` with `stringData |-` (verified byte-identical against live secret).
- `templates/rails-secrets.tftpl`: reorder `active_record_encryption_*` keys after `openid_connect_signing_key`; switch `active_record_encryption_primary_key` / `_deterministic_key` to value-on-next-line to match chart-emitted YAML.

**Stage2 root + Longhorn**
- `stage2/main.tf`: drop `host_machine_architecture` argument from `gitlab_platform` module call.
- `stage2/variables.tf`: add `validation` block on `kubernetes_override_domains` enforcing space-delimited lowercase FQDNs.
- `stage2/longhorn-storage/longhorn-crds.tf`: `data.http.longhorn_crd[count.index].body` → `.response_body` (hashicorp/http v3 deprecation).

## Test plan

- [ ] `task precommit` passes locally
- [ ] `terraform validate` clean for stage2
- [ ] `terraform plan` shows no perpetual `rails-secret` drift
- [ ] Ansible re-run on existing cluster reports no false-positive `changed` for the touched roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
