### PR TITLE
fix(host_setup): mask multipathd + bump tool versions + ignore unfixable trivy CVEs

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -46,6 +46,45 @@ vulnerabilities:
     statement: libpng transitive dependency via graphviz
   - id: CVE-2026-22801
     statement: libpng transitive dependency via graphviz
+  # Go stdlib vulnerabilities affecting kubectl/task/terraform/trivy binaries
+  # Fix landed in Go 1.25.10 / 1.26.3; kubectl 1.36.1 ships Go 1.26.2, task 3.51.1
+  # and terraform 1.15.4 still on older Go. trivy 0.70.0 is latest but pre-Go-1.26.3.
+  # Re-evaluate after upstream rebuilds (~30 days).
+  # TODO: Remove once kubectl >= 1.36.2 and trivy >= 0.71.0 (or equivalent rebuilds) land.
+  - id: CVE-2026-33811
+    statement: Go stdlib LookupCNAME cgo DNS resolver - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
+    expired_at: 2026-06-22
+  - id: CVE-2026-33814
+    statement: Go stdlib HTTP/2 SETTINGS frames infinite loop - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
+    expired_at: 2026-06-22
+  - id: CVE-2026-39820
+    statement: Go stdlib net/mail ParseAddress malformed input - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
+    expired_at: 2026-06-22
+  - id: CVE-2026-39836
+    statement: Go stdlib net.Dial/LookupPort NUL byte panic (Windows-only, low risk on Alpine) - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
+    expired_at: 2026-06-22
+  - id: CVE-2026-42499
+    statement: Go stdlib net/mail consumePhrase DoS - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
+    expired_at: 2026-06-22
+  - id: CVE-2026-39823
+    statement: Go stdlib net/url parsing in kubectl/trivy - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
+    expired_at: 2026-06-22
+  - id: CVE-2026-39825
+    statement: Go stdlib net/http/httputil ReverseProxy query forwarding in kubectl/trivy - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
+    expired_at: 2026-06-22
+  - id: CVE-2026-39826
+    statement: Go stdlib html/template script tag escaping in kubectl/trivy - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
+    expired_at: 2026-06-22
+  # Trivy 0.70.0 transitive dependencies - fixed upstream, awaiting next Trivy release
+  - id: CVE-2026-46680
+    statement: containerd user ID handling bypass in trivy v0.70.0 (vendored v1.7.30/v2.2.2) - fixed in containerd 1.7.32/2.2.4, awaiting trivy rebuild
+    expired_at: 2026-06-22
+  - id: CVE-2026-45022
+    statement: go-git parsing flaw in trivy v0.70.0 (vendored v5.17.2) - fixed in go-git 5.19.0, awaiting trivy rebuild
+    expired_at: 2026-06-22
+  - id: CVE-2026-44973
+    statement: go-billy path traversal in trivy v0.70.0 (vendored v5.8.0) - fixed in go-billy 5.9.0, awaiting trivy rebuild
+    expired_at: 2026-06-22
 
 misconfigurations:
   # Dockerfile checks - acceptable for this use case

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ ARG BUILDPLATFORM
 ARG BUILDARCH
 
 # https://dl.k8s.io/release/stable.txt
-ARG KUBECTL_VERSION=1.36.0
+ARG KUBECTL_VERSION=1.36.1
 # https://github.com/helm/helm/releases
-ARG HELM_VERSION=4.1.4
+ARG HELM_VERSION=4.2.0
 # https://developer.hashicorp.com/terraform/install
-ARG TERRAFORM_VERSION=1.15.2
+ARG TERRAFORM_VERSION=1.15.4
 # https://github.com/go-task/task/releases
-ARG TASKFILE_VERSION=3.50.0
+ARG TASKFILE_VERSION=3.51.1
 # https://github.com/aquasecurity/trivy/releases
 ARG TRIVY_VERSION=0.70.0
 
@@ -35,7 +35,7 @@ RUN set -eux; \
   curl=8.14.1-r2 \
   bash=5.2.37-r0 \
   jq=1.7.1-r0 \
-  bind-tools=9.18.47-r0 \
+  bind-tools=9.18.49-r0 \
   git=2.47.3-r0 \
   graphviz=12.2.0-r0 \
   python3=3.12.13-r0 \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![CI](https://github.com/chrisleekr/homelab-infrastructure/actions/workflows/push.yml/badge.svg)](https://github.com/chrisleekr/homelab-infrastructure/actions/workflows/push.yml)
 [![Container Security](https://github.com/chrisleekr/homelab-infrastructure/actions/workflows/container-security.yml/badge.svg)](https://github.com/chrisleekr/homelab-infrastructure/actions/workflows/container-security.yml)
-[![Terraform](https://img.shields.io/badge/terraform-1.15.2-blue)](https://www.terraform.io/)
-[![Kubernetes](https://img.shields.io/badge/kubernetes-1.36.0-blue)](https://kubernetes.io/)
+[![Terraform](https://img.shields.io/badge/terraform-1.15.4-blue)](https://www.terraform.io/)
+[![Kubernetes](https://img.shields.io/badge/kubernetes-1.36.1-blue)](https://kubernetes.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 > Provisioning a single-node Kubernetes cluster with kubeadm/k3s, Ansible and Terraform
@@ -77,10 +77,10 @@ homelab-infrastructure/
 <!-- VERSIONS_START - Do not remove this comment, used by sync-versions workflow -->
 | Tool | Version |
 |------|---------|
-| kubectl | 1.36.0 |
-| helm | 4.1.4 |
-| terraform | 1.15.2 |
-| taskfile | 3.50.0 |
+| kubectl | 1.36.1 |
+| helm | 4.2.0 |
+| terraform | 1.15.4 |
+| taskfile | 3.51.1 |
 | trivy | 0.70.0 |
 <!-- VERSIONS_END - Do not remove this comment -->
 

--- a/stage1/requirements.yml
+++ b/stage1/requirements.yml
@@ -7,4 +7,6 @@ collections:
     version: ">=12.0.1"
 
   - name: kubernetes.core
-    version: ">=6.2.0"
+    # 6.4.0 adds Helm v4 compatibility (issue #1038); <6.4.0 emits the
+    # removed `helm list --all` flag and fails against Helm 4.x.
+    version: ">=6.4.0"

--- a/stage1/roles/host_setup/tasks/update-multipath.yml
+++ b/stage1/roles/host_setup/tasks/update-multipath.yml
@@ -1,5 +1,15 @@
 ---
-# https://longhorn.io/kb/troubleshooting-volume-with-multipath/
+# Longhorn flags Multipathd condition as False whenever the multipathd
+# service is running on a node, regardless of blacklist state. The check
+# runs `multipathd show status` and treats any non-empty output as failure.
+# Ref: https://github.com/longhorn/longhorn-manager/blob/v1.9.0/controller/monitor/environment_check_monitor.go
+# KB:  https://longhorn.io/kb/troubleshooting-volume-with-multipath/
+#
+# We keep the blacklist for defense in depth (in case the service is ever
+# unmasked manually) and stop + disable + mask the units so Longhorn's
+# environment check clears. The previous `notify: restart multipathd`
+# handler was removed intentionally: a masked unit cannot be restarted,
+# and the service is no longer expected to run on these hosts.
 
 - name: Check if /etc/multipath.conf exists
   ansible.builtin.stat:
@@ -23,4 +33,15 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
     create: true
     mode: "0644"
-  notify: "restart multipathd"
+
+- name: Stop, disable and mask multipathd units
+  # Mask the socket as well: otherwise systemd re-activates multipathd.service
+  # on /dev/mapper/control access via socket activation.
+  ansible.builtin.systemd_service:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+    masked: true
+  loop:
+    - multipathd.service
+    - multipathd.socket

--- a/stage1/site.yml
+++ b/stage1/site.yml
@@ -6,9 +6,6 @@
     - role: host_setup
       tags: [host_setup]
   handlers:
-    - name: Multipathd handlers
-      ansible.builtin.import_tasks:
-        file: handlers/multipathd.yml
     - name: Fail2ban handlers
       ansible.builtin.import_tasks:
         file: handlers/fail2ban.yml

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -8,11 +8,16 @@ scan:
   scanners:
     - vuln
     - misconfig
-  # Skip Ansible collections directory
-  # Collections contain Jinja2 templates (*.j2) that trigger Dockerfile parse errors
-  # Path: /tmp/.venv persists because shell glob '*' doesn't match dotfiles
+  # Paths are absolute within the scanned image. The CI job runs
+  # `trivy image --config trivy.yaml`, so build-context paths (e.g. container/...)
+  # never match; they must be the container filesystem paths.
+  # Third-party Ansible collections install in two locations: ansible-galaxy
+  # writes to the galaxy home (/root/.ansible/collections) while others land in
+  # the Python venv site-packages. Their test/molecule fixtures (kubernetes.core,
+  # community.okd) ship pods with default security contexts that trip
+  # KSV-0118/KSV-0014 HIGH misconfigs. Skip both trees.
   skip-dirs:
+    - "/root/.ansible"
     - "/tmp/.venv/lib/python3.12/site-packages/ansible_collections"
-    # Skip pre-commit cache - contains third-party hooks with their own Dockerfiles/manifests
-    - "container/root/.cache"
-    - "container/root/.ansible"
+    # Pre-commit cache: third-party hooks with their own Dockerfiles/manifests.
+    - "/root/.cache"


### PR DESCRIPTION


### Why

Longhorn's node controller flags the `Multipathd` condition as `False` on every node where `multipathd` is running, regardless of `/etc/multipath.conf` blacklist state. The check is purely service-existence-based — it runs `multipathd show status` and any non-empty output trips the condition.

Verified against upstream source (pinned to deployed version v1.9.0):

> https://github.com/longhorn/longhorn-manager/blob/v1.9.0/controller/monitor/environment_check_monitor.go

```go
args := []string{"show", "status"}
if result, _ := nsexec.Execute(nil, "multipathd", args, lhtypes.ExecuteDefaultTimeout); result != "" {
    collectedData.conditions = types.SetCondition(...,
        longhorn.NodeConditionTypeMultipathd,
        longhorn.ConditionStatusFalse,
        string(longhorn.NodeConditionReasonMultipathdIsRunning), ...)
    return
}
```

The pre-existing blacklist eliminates the actual interference risk but cannot clear the condition. Upstream tracking: [longhorn/longhorn#6755](https://github.com/longhorn/longhorn/issues/6755) (still open, `investigation-needed`).

### What

- Keep the `/etc/multipath.conf` blacklist (`devnode "^sd[a-z0-9]+"`) as defense in depth.
- Add a `systemd_service` task that stops, disables, and masks both `multipathd.service` and `multipathd.socket`. Socket masking is required because systemd otherwise re-activates the service on `/dev/mapper/control` access.
- Drop the `notify: restart multipathd` from the blockinfile task (masked units can't be restarted).
- Delete `stage1/handlers/multipathd.yml` and its `import_tasks` block in `stage1/site.yml` — the handler is now unreachable.

### Safety

- Verified on `clsrv-v2` that `multipath -ll` is empty — nothing actually uses multipath on this cluster, so disabling is safe.
- The `systemd_service` task is fully idempotent — already-masked units report `ok` not `changed`.
- Greenfield and already-provisioned nodes both converge cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved multipath service handling to prevent conflicts.
  * Refined security scanning to exclude additional build-context paths.

* **Chores**
  * Updated tool versions: Kubectl 1.36.1, Helm 4.2.0, Terraform 1.15.4, Task 3.51.1.
  * Updated Ansible collection to 6.4.0 for Helm v4 compatibility.
  * Added vulnerability ignore entries for upstream package rebuilds.
  * Updated documentation and version badges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/homelab-infrastructure/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->