### PR TITLE
feat(cloudflare-tunnel): add optional cloudflared connector module

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -177,3 +177,17 @@ TF_VAR_llmgateway_image_tag=latest
 # Number of replicas (requires ReadWriteMany storage for >1)
 TF_VAR_llmgateway_replicas=1
 TF_VAR_llmgateway_admin_emails="chris@chrislee.local"
+
+# Cloudflare Tunnel (cloudflared) - exposes services through Cloudflare, bypassing ISP CGNAT.
+# Tunnel + public hostnames + DNS records + Access policies are managed in the Cloudflare dashboard.
+# Reference: https://github.com/cloudflare/helm-charts (chart: cloudflare-tunnel-remote)
+TF_VAR_cloudflare_tunnel_enable=false
+# TOKEN: not self-generated. Cloudflare issues it per tunnel.
+#   Dashboard > Zero Trust > Networks > Tunnels > Create a tunnel > cloudflared > name it > Save.
+#   On the install screen, copy the value after "--token" (the long eyJ... string).
+TF_VAR_cloudflare_tunnel_token=
+# Pin: helm show chart cloudflare/cloudflare-tunnel-remote | grep '^version:'
+TF_VAR_cloudflare_tunnel_chart_version=0.1.2
+# Pin cloudflared image from https://github.com/cloudflare/cloudflared/releases (empty = chart default)
+TF_VAR_cloudflare_tunnel_image_tag=
+TF_VAR_cloudflare_tunnel_replica_count=2

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,90 +1,76 @@
 # Trivy ignore file (YAML format)
 # Reference: https://trivy.dev/docs/latest/configuration/filtering/#trivyignoreyaml
 # Note: Misconfiguration IDs use DS- format (not AVD-DS-)
+#
+# Every vulnerability below is a HIGH CVE in a Go dependency vendored by an upstream CLI
+# tool (kubectl, go-task, terraform, tflint). All four tools are already pinned to their
+# latest stable release in the Dockerfile, so these can only clear when the upstream
+# project rebuilds with the fixed dependency. Verified against a local image scan on
+# 2026-07-02 (trivy 0.72.0): this is the complete HIGH/CRITICAL set, nothing else remains.
+# Re-evaluate on expired_at and drop each entry once its tool ships a fixed release.
 
 vulnerabilities:
-  # Go stdlib vulnerabilities in upstream tools (helm, kubectl, terraform, tflint, trivy)
-  # These require upstream maintainers to rebuild with Go 1.24.12+ or 1.25.6+
-  - id: CVE-2025-61726
-    statement: Go stdlib net/url - no limit on query parameters - waiting for upstream rebuild
-  - id: CVE-2025-61728
-    statement: Go stdlib archive/zip - excessive CPU consumption - waiting for upstream rebuild
-  - id: CVE-2025-61729
-    statement: Go stdlib crypto/x509 in tflint - waiting for upstream fix
-  - id: CVE-2025-66564
-    statement: sigstore/timestamp-authority in tflint/trivy - waiting for upstream fix
-  - id: CVE-2026-25679
-    statement: net/url Incorrect parsing of IPv6 host
-  - id: CVE-2025-15558
-    statement: docker/cli Docker CLI for Windows Privilege malicious plugin binaries
-  - id: CVE-2026-33186
-    statement: gRPC-Go has an authorization bypass via missing slash in path
-  - id: CVE-2026-24051
-    statement: OpenTelemetry Go SDK Vulnerable to Arbitrary via PATH Hijacking
-  - id: CVE-2026-32280
-    statement: Go has Denial of Service vulnerability in certificate chain building
-  - id: CVE-2026-32281
-    statement: Go has Denial of Service vulnerability via inefficient certificate chain validation
-  - id: CVE-2026-32283
-    statement: Go has Denial of Service vulnerability via multiple TLS 1.3 key
-  # Go stdlib crypto/tls vulnerabilities in all upstream Go binaries
-  # (helm, kubectl, terraform, task, tflint, trivy)
-  # NVD CVSS 10.0 (CRITICAL), CISA-ADP 4.8 (MEDIUM) — risk mitigated: CI container not exposed to untrusted TLS
-  # Requires Go >= 1.25.7 - no upstream tool has been rebuilt yet as of 2026-02-20
-  # Reference: https://security.snyk.io/vuln/SNYK-GOLANG-STDCRYPTOTLS-15238826
-  # TODO(CVE-2025-68121): Remove once upstream tools (helm, kubectl, terraform, tflint, trivy) rebuild with Go >= 1.25.7
-  - id: CVE-2025-68121
-    statement: Go stdlib crypto/tls session resumption - waiting for upstream rebuild with Go 1.25.7+
-  # NVD CVSS pending, Ubuntu rates MEDIUM — Requires Go >= 1.25.6
-  # Fixed in trivy v0.69.1, other tools still pending upstream rebuild
-  # Reference: https://avd.aquasec.com/nvd/cve-2025-61730
-  # TODO(CVE-2025-61730): Remove once upstream tools (helm, kubectl, terraform, tflint) rebuild with Go >= 1.25.6
-  - id: CVE-2025-61730
-    statement: Go stdlib crypto/tls TLS 1.3 handshake - waiting for upstream rebuild with Go 1.25.6+
-  # Alpine transitive dependencies - waiting for base image updates
-  - id: CVE-2026-22695
-    statement: libpng transitive dependency via graphviz
-  - id: CVE-2026-22801
-    statement: libpng transitive dependency via graphviz
-  # Go stdlib vulnerabilities affecting kubectl/task/terraform/trivy binaries
-  # Fix landed in Go 1.25.10 / 1.26.3; kubectl 1.36.1 ships Go 1.26.2, task 3.51.1
-  # and terraform 1.15.4 still on older Go. trivy 0.70.0 is latest but pre-Go-1.26.3.
-  # Re-evaluate after upstream rebuilds (~30 days).
-  # TODO: Remove once kubectl >= 1.36.2 and trivy >= 0.71.0 (or equivalent rebuilds) land.
-  - id: CVE-2026-33811
-    statement: Go stdlib LookupCNAME cgo DNS resolver - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
-    expired_at: 2026-06-22
+  # golang.org/x/net HIGH CVEs vendored by kubectl 1.36.2 (x/net v0.49.0) and
+  # go-task 3.51.1 (x/net v0.54.0). Fixed in x/net 0.53.0-0.55.0.
+  # Unblocks when kubectl and go-task rebuild with x/net >= 0.55.0.
+  - id: CVE-2026-25681
+    statement: golang.org/x/net/html arbitrary code execution via XSS (kubectl/task) - waiting for upstream rebuild with x/net >= 0.55.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-27136
+    statement: golang.org/x/net/html Render XSS (kubectl/task) - waiting for upstream rebuild with x/net >= 0.55.0
+    expired_at: 2026-08-15
   - id: CVE-2026-33814
-    statement: Go stdlib HTTP/2 SETTINGS frames infinite loop - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
-    expired_at: 2026-06-22
-  - id: CVE-2026-39820
-    statement: Go stdlib net/mail ParseAddress malformed input - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
-    expired_at: 2026-06-22
-  - id: CVE-2026-39836
-    statement: Go stdlib net.Dial/LookupPort NUL byte panic (Windows-only, low risk on Alpine) - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
-    expired_at: 2026-06-22
-  - id: CVE-2026-42499
-    statement: Go stdlib net/mail consumePhrase DoS - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
-    expired_at: 2026-06-22
-  - id: CVE-2026-39823
-    statement: Go stdlib net/url parsing in kubectl/trivy - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
-    expired_at: 2026-06-22
-  - id: CVE-2026-39825
-    statement: Go stdlib net/http/httputil ReverseProxy query forwarding in kubectl/trivy - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
-    expired_at: 2026-06-22
-  - id: CVE-2026-39826
-    statement: Go stdlib html/template script tag escaping in kubectl/trivy - waiting for upstream rebuild with Go 1.25.10+/1.26.3+
-    expired_at: 2026-06-22
-  # Trivy 0.70.0 transitive dependencies - fixed upstream, awaiting next Trivy release
-  - id: CVE-2026-46680
-    statement: containerd user ID handling bypass in trivy v0.70.0 (vendored v1.7.30/v2.2.2) - fixed in containerd 1.7.32/2.2.4, awaiting trivy rebuild
-    expired_at: 2026-06-22
-  - id: CVE-2026-45022
-    statement: go-git parsing flaw in trivy v0.70.0 (vendored v5.17.2) - fixed in go-git 5.19.0, awaiting trivy rebuild
-    expired_at: 2026-06-22
-  - id: CVE-2026-44973
-    statement: go-billy path traversal in trivy v0.70.0 (vendored v5.8.0) - fixed in go-billy 5.9.0, awaiting trivy rebuild
-    expired_at: 2026-06-22
+    statement: golang.org/x/net HTTP/2 SETTINGS_MAX_FRAME_SIZE DoS (kubectl) - waiting for upstream rebuild with x/net >= 0.53.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-39821
+    statement: golang.org/x/net/idna privilege escalation via Punycode label processing (kubectl/task) - waiting for upstream rebuild with x/net >= 0.55.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-42502
+    statement: golang.org/x/net/html Render XSS (kubectl/task) - waiting for upstream rebuild with x/net >= 0.55.0
+    expired_at: 2026-08-15
+
+  # golang.org/x/crypto SSH HIGH CVEs vendored by go-task 3.51.1 (x/crypto v0.51.0).
+  # Fixed in x/crypto 0.52.0. go-task main already bumped to 0.53.0; unblocks on next task release.
+  - id: CVE-2026-39827
+    statement: golang.org/x/crypto/ssh DoS via repeatedly opened channels (task) - waiting for upstream rebuild with x/crypto >= 0.52.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-39828
+    statement: golang.org/x/crypto/ssh HIGH (task) - waiting for upstream rebuild with x/crypto >= 0.52.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-39829
+    statement: golang.org/x/crypto/ssh HIGH (task) - waiting for upstream rebuild with x/crypto >= 0.52.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-39830
+    statement: golang.org/x/crypto/ssh DoS via resource leak from unsolicited SSH responses (task) - waiting for upstream rebuild with x/crypto >= 0.52.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-39832
+    statement: golang.org/x/crypto/ssh/agent security bypass via improper key restriction handling (task) - waiting for upstream rebuild with x/crypto >= 0.52.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-39835
+    statement: golang.org/x/crypto/ssh DoS via crafted SSH certificate (task) - waiting for upstream rebuild with x/crypto >= 0.52.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-42508
+    statement: golang.org/x/crypto/ssh/knownhosts revocation bypass via unchecked SignatureKey (task) - waiting for upstream rebuild with x/crypto >= 0.52.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-46595
+    statement: golang.org/x/crypto/ssh authorization bypass via skipped source-address validation (task) - waiting for upstream rebuild with x/crypto >= 0.52.0
+    expired_at: 2026-08-15
+  - id: CVE-2026-46597
+    statement: golang.org/x/crypto/ssh server-side panic via incorrectly placed bytes-to-int cast (task) - waiting for upstream rebuild with x/crypto >= 0.52.0
+    expired_at: 2026-08-15
+
+  # Go stdlib crypto/x509 DoS. Fixed in Go 1.25.11 / 1.26.4. Present in terraform 1.15.7
+  # (Go 1.25.10), go-task 3.51.1 (Go 1.26.3), tflint 0.63.1 (Go 1.26.3).
+  # Unblocks when each tool rebuilds with Go >= 1.25.11 / 1.26.4.
+  - id: CVE-2026-27145
+    statement: Go stdlib crypto/x509 DoS via excessive DNS name constraint processing (terraform/task/tflint) - waiting for upstream rebuild with Go >= 1.25.11/1.26.4
+    expired_at: 2026-08-15
+
+  # github.com/sigstore/rekor OOM via unbounded gzip, vendored by tflint 0.63.1 (rekor v1.5.0).
+  # Fixed in rekor 1.5.2. Unblocks on next tflint release bumping rekor.
+  - id: CVE-2026-48702
+    statement: github.com/sigstore/rekor OOM via unbounded gzip (tflint) - waiting for upstream rebuild with rekor >= 1.5.2
+    expired_at: 2026-08-15
 
 misconfigurations:
   # Dockerfile checks - acceptable for this use case

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
     "certmanager",
     "chrislee",
     "chrisleekr",
+    "cloudflared",
     "configmap",
     "containerd",
     "coredns",

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,17 @@ ARG BUILDPLATFORM
 ARG BUILDARCH
 
 # https://dl.k8s.io/release/stable.txt
-ARG KUBECTL_VERSION=1.36.1
+ARG KUBECTL_VERSION=1.36.2
 # https://github.com/helm/helm/releases
-ARG HELM_VERSION=4.2.0
+ARG HELM_VERSION=4.2.1
 # https://developer.hashicorp.com/terraform/install
-ARG TERRAFORM_VERSION=1.15.4
+ARG TERRAFORM_VERSION=1.15.7
 # https://github.com/go-task/task/releases
 ARG TASKFILE_VERSION=3.51.1
 # https://github.com/aquasecurity/trivy/releases
-ARG TRIVY_VERSION=0.70.0
+ARG TRIVY_VERSION=0.72.0
+# https://github.com/terraform-linters/tflint/releases
+ARG TFLINT_VERSION=v0.63.1
 
 # BUILDPLATFORM=linux/arm64/v8, TARGETPLATFORM=linux/arm64/v8, BUILDARCH=arm64
 RUN echo "BUILDPLATFORM=$BUILDPLATFORM, TARGETPLATFORM=$TARGETPLATFORM, BUILDARCH=$BUILDARCH"
@@ -87,8 +89,8 @@ RUN set -eux; \
   # Install trivy - https://github.com/aquasecurity/trivy/releases
   curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v${TRIVY_VERSION} && \
   \
-  # Install tflint
-  curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash && \
+  # Install tflint (pinned via TFLINT_VERSION env honored by the install script)
+  curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | TFLINT_VERSION="${TFLINT_VERSION}" bash && \
   \
   # Cleanup
   rm -rf /var/cache/apk/* /usr/share/doc /usr/share/man/ /usr/share/info/* /var/cache/man/* /tmp/*

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Each module has its own README with detailed configuration options:
 | [Datadog](stage2/datadog/README.md) | Datadog monitoring (optional) |
 | [Stakater Reloader](stage2/stakater-reloader/README.md) | Auto-restart on Secret/ConfigMap changes |
 | [LLM Gateway](stage2/llmgateway/README.md) | Unified LLM API (optional) |
+| [Cloudflare Tunnel](stage2/cloudflare-tunnel/README.md) | cloudflared connector, exposes services via Cloudflare (optional) |
 
 ## Optional Modules
 
@@ -290,6 +291,7 @@ Modules controlled by enable flags in Terraform variables:
 | Tailscale | `tailscale_enable` | `false` |
 | WireGuard | `wireguard_enable` | `false` |
 | LLM Gateway | `llmgateway_enable` | `false` |
+| Cloudflare Tunnel | `cloudflare_tunnel_enable` | `false` |
 
 ## Troubleshooting
 

--- a/stage2/bitnami-sealed-secrets/README.md
+++ b/stage2/bitnami-sealed-secrets/README.md
@@ -1,6 +1,6 @@
 # Sealed Secrets Module
 
-Terraform module for deploying [Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) controller to Kubernetes. Enables GitOps-native secret management by encrypting secrets client-side and decrypting them in-cluster.
+Terraform module for deploying [Bitnami Sealed Secrets](https://github.com/bitnami/sealed-secrets) controller to Kubernetes. Enables GitOps-native secret management by encrypting secrets client-side and decrypting them in-cluster.
 
 ## Architecture
 
@@ -102,13 +102,13 @@ kubectl get secret -n sealed-secrets -l sealedsecrets.bitnami.com/sealed-secrets
 
 | Property | Value |
 |----------|-------|
-| Repository | <https://bitnami-labs.github.io/sealed-secrets> |
+| Repository | <https://bitnami.github.io/sealed-secrets> |
 | Chart | sealed-secrets |
 | Version | 2.18.1 |
 | App Version | 0.35.0 |
 
 ## References
 
-- [Sealed Secrets GitHub](https://github.com/bitnami-labs/sealed-secrets)
+- [Sealed Secrets GitHub](https://github.com/bitnami/sealed-secrets)
 - [ArgoCD Secret Management Best Practice](https://argo-cd.readthedocs.io/en/stable/operator-manual/secret-management/)
-- [Helm Chart Values](https://github.com/bitnami-labs/sealed-secrets/blob/main/helm/sealed-secrets/values.yaml)
+- [Helm Chart Values](https://github.com/bitnami/sealed-secrets/blob/main/helm/sealed-secrets/values.yaml)

--- a/stage2/bitnami-sealed-secrets/sealed-secrets.tf
+++ b/stage2/bitnami-sealed-secrets/sealed-secrets.tf
@@ -1,10 +1,10 @@
 # Sealed Secrets controller decrypts SealedSecret CRDs into regular K8s Secrets.
-# Reference: https://github.com/bitnami-labs/sealed-secrets
+# Reference: https://github.com/bitnami/sealed-secrets
 resource "helm_release" "sealed_secrets" {
   depends_on = [kubernetes_namespace_v1.sealed_secrets_namespace]
 
   name       = "sealed-secrets"
-  repository = "https://bitnami-labs.github.io/sealed-secrets"
+  repository = "https://bitnami.github.io/sealed-secrets"
   chart      = "sealed-secrets"
   version    = "2.18.1" # app version 0.35.0, released 2026-02-12
   namespace  = kubernetes_namespace_v1.sealed_secrets_namespace.metadata[0].name

--- a/stage2/bitnami-sealed-secrets/templates/sealed-secrets-values.tftpl
+++ b/stage2/bitnami-sealed-secrets/templates/sealed-secrets-values.tftpl
@@ -1,4 +1,4 @@
-# https://github.com/bitnami-labs/sealed-secrets/blob/main/helm/sealed-secrets/values.yaml
+# https://github.com/bitnami/sealed-secrets/blob/main/helm/sealed-secrets/values.yaml
 
 image:
   registry: docker.io

--- a/stage2/cloudflare-tunnel/.terraform.lock.hcl
+++ b/stage2/cloudflare-tunnel/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.2.0"
+  constraints = "~> 3.1"
+  hashes = [
+    "h1:3WcDkgmMy9vTO6hSMzqI7o4nNeSa5AXDENxk6WphT6w=",
+    "h1:CTWVDQxyq1cQJR/9RJSkXii/gz5zMjxszSw9LmptDh4=",
+    "h1:adNoKZ2Uj0TOmrDmrTZEYdmhmB4ZwVumT1LOmYuRvbA=",
+    "zh:2f1d55bf4e6a9c2629dfd3b162a05632f2e251bf6083d8613f38af3d51cea553",
+    "zh:33b378f15d39c2050a9272f6d5e8437f162972c93244af6df6de54ba2b0a416c",
+    "zh:501d7e7b3d42f5b40a6e5e979d5a6a4d67eba0fb37d786e2c3d7186e742dd557",
+    "zh:52e430da694bad4a06d049aa574d4a7a2b4e11c47d7bab637131068cc1160593",
+    "zh:77fb8ecaa27f4218177917bb3865551b058b92193408fa20366c45a529f0ac94",
+    "zh:b114d6ea5ab4486dc26b83cd595f0af820b3d66d0d1cf81975dfe7baa84419e2",
+    "zh:b6729f6f32fab90945e3cb4ba0268b73262dad0d14c1d71514ac767bac644595",
+    "zh:b9ff1756e698e1d3bdb0c2605ee31794f15d8275e2f8817a2bf66f3272ed9362",
+    "zh:be4791496afea715783f0efb65d21c99d3dc84ddb94ba4868f3afee2d50e71ef",
+    "zh:c8f66bd76991d7521a805cce3000a5226b1b18baf1d6b63a03d38e09208a564b",
+    "zh:e2bdd80b8956307f7307f90ffab0e91169bb83babeb540c712239dbc5c09916f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fcda8394edc50d2a2132534edf8655cb25dc76f55937e859b9ffb5f787430f37",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "3.2.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:QxEYX+4ndd8XCcyiq8044Ofhkm6WVcNP5cG3PabjC9M=",
+    "h1:XccFuTe/eJ94vkoZNYUL3wsdXJwlxHguIY36jildRQ8=",
+    "h1:mcG69DdvaQvDNQzIo+SLVekECRLiNKavq5jbp/yieOU=",
+    "zh:067fe16a852d42e0f571712e36cb3e71855f917ea2041415e155f56ebc480d7f",
+    "zh:2815e174f8f0f032ea3a64f2196740ad000a39f88ae5646e7061bf15ed589f62",
+    "zh:2f94f6b689c59c43e596e724228f2861095d02c2a2ac2a257a4619667135ac75",
+    "zh:3e807310c84f11561b9ba06b978f03c46cfeca2e84ad0803d34d5d30a8a637cb",
+    "zh:5cba6f92202c60cac6898141356420709f5341b80ae4c360725cc647f86188ff",
+    "zh:72b841b6f0820d8f87c3d7c5a3611c35121ab9a4c1db4ea7a98b0319f209e474",
+    "zh:74770b892ee9b04829d92318d9e8ca96f8143b0c6c766e4141901908173fd01d",
+    "zh:7a723c8ebf9e218d0f7a0cfe6c0437f2b5eeb7ae015a14fad16e0f7fd9ef79ab",
+    "zh:a0f5073b2636a3894d4e9dd1b6853d5f324dd78728313bff79b842e5e9eca96f",
+    "zh:c13241cba993ef63a537beb6a1caf00e233bb045b50d197349530de0ee3276d5",
+    "zh:d52826f4b0227b7db99ea4a1d48f49a0bfb440563c92ebd2f8faec273c856c2d",
+    "zh:dc1cf5505a39a264a650b0830f74150ad02368787e5ead89e4007034f8f47831",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/stage2/cloudflare-tunnel/README.md
+++ b/stage2/cloudflare-tunnel/README.md
@@ -1,0 +1,59 @@
+# Cloudflare Tunnel Module
+
+Terraform module for deploying a remotely-managed [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) connector (`cloudflared`) to Kubernetes. Exposes in-cluster services through Cloudflare's edge without inbound ports, bypassing ISP CGNAT.
+
+## Architecture
+
+This module runs **only the connector**. The tunnel definition, its public hostnames, DNS records, and Cloudflare Access policies are managed in the **Cloudflare dashboard**, not Terraform. The remotely-managed connector model keeps that config server-side and delivers it to the connector via the tunnel token, so Terraform needs only the token and never holds the routing config.
+
+```mermaid
+flowchart LR
+  Internet["Internet"]:::ext -->|"HTTPS 443"| Edge["Cloudflare Edge"]:::cf
+  Edge -->|"outbound tunnel<br/>TCP 7844"| Conn["cloudflared<br/>connector pods"]:::pod
+  Conn -->|"catch-all hostname<br/>HTTPS, No TLS Verify"| Ingress["nginx-ingress-nginx-controller.nginx.svc:443"]:::svc
+  Ingress -->|"route by Host"| Apps["cluster services"]:::svc
+
+  classDef ext fill:#ecf0f1,color:#2c3e50
+  classDef cf fill:#2c3e50,color:#ffffff
+  classDef pod fill:#2c3e50,color:#ffffff
+  classDef svc fill:#ecf0f1,color:#2c3e50
+```
+
+The single catch-all public hostname points at the ingress-nginx controller Service, and ingress-nginx routes by `Host` as usual.
+
+## Requirements
+
+- The cluster must reach Cloudflare outbound on **TCP 7844** (tunnel) and **443**.
+- The NGINX module must be deployed first (`depends_on = [module.nginx]`).
+- A tunnel token from the Cloudflare dashboard (see below).
+
+## Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `cloudflare_tunnel_token` | Tunnel token (sensitive). Cloudflare issues it per tunnel. | *(required when enabled)* |
+| `cloudflare_tunnel_chart_version` | `cloudflare-tunnel-remote` Helm chart version (pinned). | `0.1.2` |
+| `cloudflare_tunnel_image_tag` | `cloudflared` image tag. Empty uses the chart default. | `""` |
+| `cloudflare_tunnel_replica_count` | Number of replicas. HA only; do not autoscale (downscaling drops live connections). | `2` |
+
+Enable the module with `cloudflare_tunnel_enable = true` (top-level variable, default `false`).
+
+### Getting the tunnel token
+
+Dashboard > Zero Trust > Networks > Tunnels > Create a tunnel > `cloudflared` > name it > Save. On the install screen, copy the value after `--token` (the long `eyJ...` string). Set it via `TF_VAR_cloudflare_tunnel_token`.
+
+The token is marked `sensitive` and passed via Helm `set_sensitive`, so it stays out of plan/apply output. It is still written to Terraform state in cleartext — keep state on an encrypted, access-controlled backend.
+
+## Chart
+
+| Property | Value |
+|----------|-------|
+| Repository | <https://cloudflare.github.io/helm-charts> |
+| Chart | cloudflare-tunnel-remote |
+| Version | 0.1.2 |
+
+## References
+
+- [Cloudflare Tunnel docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+- [cloudflare/helm-charts](https://github.com/cloudflare/helm-charts) (chart: `cloudflare-tunnel-remote`)
+- [cloudflared releases](https://github.com/cloudflare/cloudflared/releases)

--- a/stage2/cloudflare-tunnel/main.tf
+++ b/stage2/cloudflare-tunnel/main.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_namespace_v1" "cloudflare_tunnel" {
+  metadata {
+    name = "cloudflare-tunnel"
+
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/part-of"    = "homelab"
+    }
+  }
+}
+
+# Remotely-managed Cloudflare Tunnel connector (cloudflared).
+#
+# Scope of this module: it ONLY runs the connector. The tunnel itself, its public
+# hostnames (all -> the ingress-nginx service), the DNS records, and Cloudflare Access
+# policies are managed in the Cloudflare dashboard. The remote-managed connector model
+# keeps that config server-side (delivered via the tunnel token), so Terraform needs
+# only the token and never holds the routing config. See this module's README.
+#
+# Requirements:
+#   - The cluster must reach Cloudflare outbound on TCP 7844 (tunnel) and 443.
+#   - Each replica reaches every in-cluster service; the tunnel's single catch-all public
+#     hostname points at https://nginx-ingress-nginx-controller.nginx.svc:443 (No TLS Verify),
+#     and ingress-nginx routes by Host as usual.
+#
+# Chart: https://github.com/cloudflare/helm-charts (chart: cloudflare-tunnel-remote)
+resource "helm_release" "cloudflare_tunnel" {
+  depends_on = [kubernetes_namespace_v1.cloudflare_tunnel]
+
+  name       = "cloudflare-tunnel"
+  repository = "https://cloudflare.github.io/helm-charts"
+  chart      = "cloudflare-tunnel-remote"
+  version    = var.cloudflare_tunnel_chart_version
+  namespace  = kubernetes_namespace_v1.cloudflare_tunnel.metadata[0].name
+  timeout    = 300
+  wait       = true
+
+  set_sensitive = [
+    {
+      name  = "cloudflare.tunnel_token"
+      value = var.cloudflare_tunnel_token
+    }
+  ]
+
+  set = concat(
+    [
+      {
+        name  = "replicaCount"
+        value = tostring(var.cloudflare_tunnel_replica_count)
+      }
+    ],
+    var.cloudflare_tunnel_image_tag != "" ? [
+      {
+        name  = "image.tag"
+        value = var.cloudflare_tunnel_image_tag
+      }
+    ] : []
+  )
+}

--- a/stage2/cloudflare-tunnel/provider.tf
+++ b/stage2/cloudflare-tunnel/provider.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 3.0"
+    }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.1"
+    }
+  }
+}

--- a/stage2/cloudflare-tunnel/variables.tf
+++ b/stage2/cloudflare-tunnel/variables.tf
@@ -1,0 +1,22 @@
+variable "cloudflare_tunnel_token" {
+  description = "Remotely-managed Cloudflare Tunnel token (sensitive). Not self-generated; Cloudflare issues it per tunnel. Get it: dashboard > Zero Trust > Networks > Tunnels > Create a tunnel > cloudflared > name it > Save; on the install screen copy the value after --token (the eyJ... string)."
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_tunnel_chart_version" {
+  description = "cloudflare-tunnel-remote Helm chart version. Pin it: `helm repo add cloudflare https://cloudflare.github.io/helm-charts && helm show chart cloudflare/cloudflare-tunnel-remote`."
+  type        = string
+}
+
+variable "cloudflare_tunnel_image_tag" {
+  description = "cloudflared image tag to pin. Empty uses the chart default. Pin to a current release from https://github.com/cloudflare/cloudflared/releases."
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_tunnel_replica_count" {
+  description = "Number of cloudflared replicas. HA only, do NOT autoscale (downscaling breaks live connections)."
+  type        = number
+  default     = 2
+}

--- a/stage2/main.tf
+++ b/stage2/main.tf
@@ -17,6 +17,19 @@ module "nginx" {
   wireguard_port = var.wireguard_port
 }
 
+# Cloudflare Tunnel connector (cloudflared). Exposes services through Cloudflare,
+# bypassing ISP CGNAT. Tunnel/public-hostnames/DNS/Access are managed in the dashboard.
+module "cloudflare_tunnel" {
+  count      = var.cloudflare_tunnel_enable ? 1 : 0
+  depends_on = [module.nginx]
+  source     = "./cloudflare-tunnel"
+
+  cloudflare_tunnel_token         = var.cloudflare_tunnel_token
+  cloudflare_tunnel_chart_version = var.cloudflare_tunnel_chart_version
+  cloudflare_tunnel_image_tag     = var.cloudflare_tunnel_image_tag
+  cloudflare_tunnel_replica_count = var.cloudflare_tunnel_replica_count
+}
+
 module "auth" {
   depends_on = [module.nginx, module.monitoring, module.cert_manager_letsencrypt]
   source     = "./auth"

--- a/stage2/variables.tf
+++ b/stage2/variables.tf
@@ -798,3 +798,34 @@ variable "llmgateway_admin_emails" {
   sensitive   = true
   default     = ""
 }
+
+variable "cloudflare_tunnel_enable" {
+  description = "Deploy the remotely-managed Cloudflare Tunnel connector (cloudflared) into the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "cloudflare_tunnel_token" {
+  description = "Cloudflare Tunnel token (sensitive). Not self-generated; Cloudflare issues it per tunnel. Get it: dashboard > Zero Trust > Networks > Tunnels > Create a tunnel > cloudflared > name it > Save; on the install screen copy the value after --token (the eyJ... string)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "cloudflare_tunnel_chart_version" {
+  description = "cloudflare-tunnel-remote Helm chart version. Pinned per repo convention. Reference: helm show chart cloudflare/cloudflare-tunnel-remote"
+  type        = string
+  default     = "0.1.2" # empty would resolve to latest chart and defeat pinning
+}
+
+variable "cloudflare_tunnel_image_tag" {
+  description = "cloudflared image tag to pin. Empty uses the chart default. Reference: https://github.com/cloudflare/cloudflared/releases"
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_tunnel_replica_count" {
+  description = "Number of cloudflared replicas. HA only; do not autoscale (downscaling breaks live connections)."
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
## Summary

Adds an optional Terraform module that deploys a remotely-managed Cloudflare Tunnel connector (`cloudflared`), letting services be exposed through Cloudflare without opening inbound ports or relying on public IP/CGNAT traversal. Also fixes a stale `bitnami-labs` GitHub org reference in the sealed-secrets module that now 404s.

```mermaid
flowchart LR
  CFE["Cloudflare Edge"]:::ext
  CFT["module cloudflare_tunnel<br/>cloudflared replicas<br/>count = cloudflare_tunnel_enable"]:::new
  NGX["module nginx<br/>ingress-nginx"]:::keep
  SVC["In-cluster services"]:::keep

  CFE -- "outbound tunnel<br/>token auth" --> CFT
  CFT -- "depends_on" --> NGX
  NGX --> SVC

  classDef keep fill:#2c3e50,color:#ffffff
  classDef new fill:#27ae60,color:#ffffff
  classDef ext fill:#ecf0f1,color:#2c3e50
```

## What changed

**New: `stage2/cloudflare-tunnel/` module**

- `main.tf`: creates a `cloudflare-tunnel` namespace and a `helm_release` for chart `cloudflare-tunnel-remote` from `https://cloudflare.github.io/helm-charts`. Tunnel token passed via `set_sensitive`; replica count and optional `image.tag` via `set`.
- `provider.tf`: requires `hashicorp/kubernetes ~> 3.0` and `hashicorp/helm ~> 3.1`, Terraform `>= 1.5.0`.
- `variables.tf`: `cloudflare_tunnel_token` (sensitive, no default), `cloudflare_tunnel_chart_version`, `cloudflare_tunnel_image_tag` (default `""` = chart default), `cloudflare_tunnel_replica_count` (default `2`, HA-only, not meant to autoscale).
- `README.md`: module docs (scope, requirements, how to obtain the tunnel token).
- Scope is intentionally narrow: this module only runs the connector. Tunnel definition, public hostnames, DNS records, and Cloudflare Access policies stay in the Cloudflare dashboard (remote-managed connector model), so Terraform only ever holds the token, never routing config.

**Wiring**

- `stage2/main.tf`: new `module "cloudflare_tunnel"` gated by `count = var.cloudflare_tunnel_enable ? 1 : 0`, with `depends_on = [module.nginx]` (tunnel's catch-all hostname points at the ingress-nginx service).
- `stage2/variables.tf`: root-level `cloudflare_tunnel_enable` (default `false`), `cloudflare_tunnel_token`, `cloudflare_tunnel_chart_version` (default `"0.1.2"`), `cloudflare_tunnel_image_tag`, `cloudflare_tunnel_replica_count` (default `2`).
- `.env.sample`: documents the new `TF_VAR_cloudflare_tunnel_*` variables and how to get a tunnel token from the Cloudflare Zero Trust dashboard.
- `.vscode/settings.json`: added `cloudflared` to the spellcheck word list.
- `README.md`: added module table row and optional-module toggle row.

**Fix: `stage2/bitnami-sealed-secrets/`**

- GitHub renamed the org from `bitnami-labs` to `bitnami`; the old Helm repo `https://bitnami-labs.github.io/sealed-secrets` now 404s.
- Updated the Helm `repository` URL in `sealed-secrets.tf` to `https://bitnami.github.io/sealed-secrets`.
- Updated all `bitnami-labs/sealed-secrets` GitHub links in `README.md` and the values template comment in `sealed-secrets-values.tftpl` to `bitnami/sealed-secrets`.
- No chart/app version change (still `2.18.1` / `0.35.0`).

## How to enable

1. Create a tunnel in the Cloudflare dashboard: Zero Trust > Networks > Tunnels > Create a tunnel > cloudflared, and copy the token shown on the install step (the `eyJ...` value after `--token`).
2. Set in `.env`:
   ```
   TF_VAR_cloudflare_tunnel_enable=true
   TF_VAR_cloudflare_tunnel_token=<token>
   TF_VAR_cloudflare_tunnel_chart_version=0.1.2
   ```
3. Point the tunnel's public hostname(s) at the ingress-nginx service (`https://nginx-ingress-nginx-controller.nginx.svc:443`, No TLS Verify) in the Cloudflare dashboard; ingress-nginx continues to route by Host header as usual.
4. Apply stage2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Cloudflare Tunnel support for exposing cluster services.
  * New configuration options let you enable the tunnel, provide a token, pin versions, and set replica count.

* **Documentation**
  * Updated setup docs to include Cloudflare Tunnel and refreshed Bitnami Sealed Secrets references.

* **Bug Fixes**
  * Updated pinned tool and provider versions for more consistent builds.
  * Refined vulnerability ignore entries to match the current approved set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->