### PR TITLE
fix: bump ansible to 14.1.0 to match ansible-core 2.21.1

### DIFF
--- a/stage1/requirements-pip.txt
+++ b/stage1/requirements-pip.txt
@@ -1,4 +1,6 @@
-ansible==13.5.0
+# ansible must track ansible-core: ansible 14.1.0 requires ansible-core~=2.21.1
+# (ansible 13.5.0 requires ansible-core~=2.20.4 (<2.21) and breaks the 2.21.1 pin below)
+ansible==14.1.0
 ansible-core==2.21.1
 # Upgrade to 35.0.0 for urllib3 2.6.x compatibility (34.1.0 has urllib3<2.4.0 constraint)
 # Reference: https://pypi.org/project/kubernetes/35.0.0/


### PR DESCRIPTION
Fixes a pip dependency resolution conflict that was failing the stage1 Docker build ("Build & Scan Container" job) on every open PR, including main.

**Root cause**

#91 bumped `ansible-core` from `2.20.4` to `2.21.1` but left `ansible` pinned at `13.5.0`. `ansible==13.5.0` requires `ansible-core~=2.20.4` (`>=2.20.4,<2.21.0`), which is incompatible with the `ansible-core==2.21.1` pin left in place — an impossible resolution (`pip` `ResolutionImpossible`) baked into `main`.

**Fix**

Bump `ansible` to `14.1.0`, which requires `ansible-core~=2.21.1` (`>=2.21.1,<2.22.0`) per PyPI metadata, satisfying the existing `ansible-core==2.21.1` pin. Also documents the version coupling inline so future bumps of one package don't silently break the other.

**Impact**

Unblocks the two open Dependabot PRs (#86 kubernetes, #88 cryptography), which were failing only because they inherited this broken base from `main`.

```mermaid
flowchart LR
    subgraph deps["stage1/requirements-pip.txt"]
        ANS["ansible"]:::change
        COR["ansible-core==2.21.1"]:::keep
    end
    ANS -->|requires| COR

    OLD["ansible==13.5.0<br/>needs ansible-core~=2.20.4"]:::broken
    NEW["ansible==14.1.0<br/>needs ansible-core~=2.21.1"]:::fixed

    ANS -.before.-> OLD
    ANS -.after.-> NEW

    classDef change fill:#2c3e50,color:#ffffff
    classDef keep fill:#ecf0f1,color:#2c3e50
    classDef broken fill:#c0392b,color:#ffffff
    classDef fixed fill:#27ae60,color:#ffffff
```
