### PR TITLE
fix: schedule Longhorn CSI and Datadog agent onto tainted worker nodes

### DIFF
--- a/docs/adding-a-worker-node.md
+++ b/docs/adding-a-worker-node.md
@@ -170,11 +170,21 @@ kubectl get pods -A -o wide --field-selector spec.nodeName=worker-01
 ```
 
 Expect the node `Ready` with the architecture of the machine you added (`ARCH=arm64` for a
-Pi, `amd64` for an x86 box), carrying the `node.homelab/class=low-power:NoSchedule`
-taint, and running **only** `cilium`, `kube-proxy` and `node-exporter`.
+Pi, `amd64` for an x86 box), carrying its `node.homelab/class:NoSchedule` taint, and running
+only the components that deliberately tolerate it:
+
+| Component | Why it tolerates the taint |
+|-----------|----------------------------|
+| `cilium`, `kube-proxy` | CNI and service proxy, required on every node |
+| `node-exporter` | Node metrics |
+| `longhorn-manager`, `longhorn-csi-plugin`, `instance-manager`, `engine-image` | Let pods here mount Longhorn volumes. Replicas do **not** land on the worker: it has no `node.longhorn.io/create-default-disk=true` label, so Longhorn gives it no disk |
+| `datadog-agent` | Node metrics, logs and OOM-kill events |
 
 Anything else running there tolerates the taint unexpectedly and should be pinned back to
 the control plane with a `nodeSelector` in stage2.
+
+The Longhorn and Datadog tolerations match on the taint key alone (`operator: Exists`), so
+they cover any `node.homelab/class` value rather than one specific class.
 
 ## Scheduling onto the worker
 

--- a/stage2/datadog/README.md
+++ b/stage2/datadog/README.md
@@ -137,6 +137,7 @@ terraform apply
 | APM | Distributed tracing (requires app instrumentation) |
 | Cluster Agent | Kubernetes events and metadata |
 | Admission Controller | Auto-injection of tracing libraries |
+| NPM | **Disabled** - see Cost Considerations |
 
 ## Datadog Sites
 
@@ -161,6 +162,10 @@ For homelab use, consider:
 - Free tier: 5 hosts, limited retention
 - Reducing log volume with filtering
 - Disabling APM if not needed
+
+NPM (`features.npm`) is disabled. It bills a per-host NPM charge monthly, and this cluster
+never emitted the `network.*`/`dns.*` data to justify it. Disabling it does not remove the
+`system-probe` container, which `features.oomKill` requires independently.
 
 ## References
 

--- a/stage2/datadog/templates/datadog-agent.tftpl
+++ b/stage2/datadog/templates/datadog-agent.tftpl
@@ -29,8 +29,10 @@ spec:
     liveProcessCollection:
       enabled: true
 
+    # NPM has never emitted network.*/dns.* metrics or flows on this cluster, yet Datadog
+    # bills an NPM host monthly. system-probe still runs regardless, required by oomKill below.
     npm:
-      enabled: true
+      enabled: false
 
     # Enables Misconfigurations
     cspm:
@@ -66,3 +68,12 @@ spec:
     # https://docs.datadoghq.com/integrations/helm/?tab=operatorv150#configuration
     helmCheck:
       enabled: true
+
+  override:
+    nodeAgent:
+      # Exists on the bare key tolerates any node.homelab/class value, so the agent covers
+      # current and future tainted workers instead of the control plane alone.
+      tolerations:
+        - key: node.homelab/class
+          operator: Exists
+          effect: NoSchedule

--- a/stage2/longhorn-storage/README.md
+++ b/stage2/longhorn-storage/README.md
@@ -62,10 +62,77 @@ sequenceDiagram
     K8s-->>App: PVC bound, ready to use
 ```
 
+## Node Topology
+
+Storage nodes and compute nodes are separated. Only nodes labeled
+`node.longhorn.io/create-default-disk=true` get a Longhorn disk, so replicas stay on the
+control plane. Tainted workers run the CSI stack so their pods can mount volumes, but hold
+no data.
+
+```mermaid
+flowchart TB
+    PodApp["Pod with Longhorn PVC<br/>scheduled on a worker"]:::app
+    CSIWorker["Worker: longhorn-manager + csi-plugin<br/>tolerates node.homelab/class<br/>no disk, no replicas"]:::compute
+    StorageCP["Control plane: labeled create-default-disk=true<br/>holds the disk and every replica"]:::store
+
+    PodApp --> CSIWorker
+    CSIWorker -->|"volume attached over the network"| StorageCP
+
+    classDef app fill:#ecf0f1,color:#2c3e50
+    classDef compute fill:#b9770e,color:#ffffff
+    classDef store fill:#1e8449,color:#ffffff
+```
+
+The label is applied by `kubernetes_labels.longhorn_default_disk`, not by hand. Longhorn
+evaluates `createDefaultDiskLabeledNodes` only the first time it detects a node, so the
+label must exist before `helm_release.longhorn` runs. It is a hard precondition: without it
+a rebuilt control plane comes up with no disk and every PVC stays `Pending`, and nothing
+fails at apply time to tell you why.
+
+Enabling the setting does **not** remove disks from nodes Longhorn already knows about. A
+worker that joined while the setting was disabled keeps the default disk it was given;
+remove that disk in the Longhorn UI if you want it compute-only.
+
+### Applying toleration changes
+
+`defaultSettings.taintToleration` is a Longhorn [Danger Zone](https://longhorn.io/docs/1.10.1/references/settings/#danger-zone)
+setting. Longhorn will not reconcile it into a component that has running engines or
+replicas, so on a cluster with attached volumes the Setting CR can sit at `APPLIED=false`
+indefinitely:
+
+```bash
+kubectl -n longhorn-system get setting taint-toleration
+# NAME              VALUE                          APPLIED
+# taint-toleration  node.homelab/class:NoSchedule  false
+```
+
+`APPLIED=false` does not mean the toleration is missing everywhere. A newly joined node's
+instance-manager has no running engines, so it receives the toleration immediately. What
+lags is the control plane's own instance-manager, which is harmless here because the control
+plane is untainted. Check the component that actually matters rather than the flag:
+
+```bash
+kubectl -n longhorn-system get ds longhorn-csi-plugin \
+  -o jsonpath='{.spec.template.spec.tolerations}'
+kubectl -n longhorn-system get pods -o wide \
+  --field-selector spec.nodeName=<worker-node>
+```
+
+To force full reconciliation, detach every volume first, then re-apply:
+
+```bash
+kubectl scale deploy/<app> --replicas=0 -n <namespace>   # detach the workloads
+kubectl -n longhorn-system get volumes.longhorn.io \
+  -o custom-columns=NAME:.metadata.name,STATE:.status.state   # all must read "detached"
+# terraform apply, then scale back up
+```
+
 ## Resources Created
 
 - `kubernetes_namespace.longhorn` - Dedicated namespace (longhorn-system)
 - `kubernetes_secret.frontend_basic_auth` - Basic auth for UI
+- `data.kubernetes_nodes.control_plane` - Looks up the control-plane node to label
+- `kubernetes_labels.longhorn_default_disk` - Marks the control plane as the storage node
 - `helm_release.longhorn` - Longhorn Helm chart
 - `null_resource.remove_default` - Removes default StorageClass from local-path
 

--- a/stage2/longhorn-storage/longhorn.tf
+++ b/stage2/longhorn-storage/longhorn.tf
@@ -32,8 +32,50 @@ resource "kubernetes_secret_v1" "frontend_basic_auth" {
   }
 }
 
+# defaultSettings.createDefaultDiskLabeledNodes gates default-disk creation on this label,
+# and Longhorn only evaluates it the first time it detects a node. Labelling here keeps the
+# storage topology reproducible: without it a rebuilt control plane gets no disk and every
+# PVC stays Pending, with nothing failing at apply time to signal why.
+data "kubernetes_nodes" "control_plane" {
+  metadata {
+    labels = {
+      "node-role.kubernetes.io/control-plane" = ""
+    }
+  }
+
+  lifecycle {
+    postcondition {
+      condition     = length(self.nodes) > 0
+      error_message = "No control-plane node matched. Longhorn would create no default disk and every PVC would stay Pending."
+    }
+  }
+}
+
+# Deliberately not for_each/count over the node list. This module carries a module-level
+# depends_on in main.tf, which defers the data source read to apply whenever the upstream
+# module has pending changes, leaving for_each keys unknown and failing the plan. A plain
+# attribute reference tolerates an unknown value. One control plane, so index 0 is the node.
+resource "kubernetes_labels" "longhorn_default_disk" {
+  api_version = "v1"
+  kind        = "Node"
+
+  metadata {
+    name = data.kubernetes_nodes.control_plane.nodes[0].metadata[0].name
+  }
+
+  labels = {
+    "node.longhorn.io/create-default-disk" = "true"
+  }
+
+  # The label predates this resource on existing clusters, so adopt it instead of conflicting.
+  # force also makes Terraform sole owner, so destroying this strips the label. Harmless while
+  # Longhorn runs, since it only re-reads the label on first node detection.
+  force = true
+}
+
 resource "helm_release" "longhorn" {
-  depends_on = [kubernetes_namespace_v1.longhorn]
+  # Label must exist before Longhorn first detects the node, or no default disk is created.
+  depends_on = [kubernetes_namespace_v1.longhorn, kubernetes_labels.longhorn_default_disk]
 
   name       = "longhorn"
   repository = "https://charts.longhorn.io"

--- a/stage2/longhorn-storage/longhorn.tf
+++ b/stage2/longhorn-storage/longhorn.tf
@@ -36,7 +36,7 @@ resource "kubernetes_secret_v1" "frontend_basic_auth" {
 # and Longhorn only evaluates it the first time it detects a node. Labelling here keeps the
 # storage topology reproducible: without it a rebuilt control plane gets no disk and every
 # PVC stays Pending, with nothing failing at apply time to signal why.
-data "kubernetes_nodes" "control_plane" {
+data "kubernetes_nodes" "longhorn_control_plane" {
   metadata {
     labels = {
       "node-role.kubernetes.io/control-plane" = ""
@@ -60,7 +60,7 @@ resource "kubernetes_labels" "longhorn_default_disk" {
   kind        = "Node"
 
   metadata {
-    name = data.kubernetes_nodes.control_plane.nodes[0].metadata[0].name
+    name = data.kubernetes_nodes.longhorn_control_plane.nodes[0].metadata[0].name
   }
 
   labels = {

--- a/stage2/longhorn-storage/templates/longhorn-values.tftpl
+++ b/stage2/longhorn-storage/templates/longhorn-values.tftpl
@@ -20,6 +20,27 @@ defaultSettings:
   defaultReplicaCount: 1
   backupCompressionMethod: "gzip"
   snapshotMaxCount: 3
+  # Covers system-managed components only (CSI driver, instance-manager, engine-image).
+  # Omitting the value means operator Exists, which is deliberate: taint values vary per
+  # worker (worker_hosts_json sets them per node, e.g. worker-low-power), so matching on the
+  # key alone covers every worker without edits here.
+  # Danger Zone setting: Longhorn will not reconcile it into a component that has running
+  # engines or replicas, so this Setting CR can read APPLIED=false indefinitely while newly
+  # joined nodes still receive the toleration. See README.md "Applying toleration changes".
+  taintToleration: "node.homelab/class:NoSchedule"
+  # Keeps workers compute-only: Longhorn provisions a default disk only on nodes carrying
+  # node.longhorn.io/create-default-disk=true, so replicas never land on worker disks.
+  createDefaultDiskLabeledNodes: true
+
+# defaultSettings.taintToleration covers system-managed components only. longhorn-manager is
+# the one user-deployed component that must run wherever volumes mount, so it needs a
+# Helm-level toleration. The driver-deployer and UI are Deployments with no reason to sit on
+# a worker, and a toleration would only make them eligible for one.
+longhornManager:
+  tolerations:
+    - key: node.homelab/class
+      operator: Exists
+      effect: NoSchedule
 
 ingress:
   enabled: true


### PR DESCRIPTION
## What changed

New arm64 worker `clsrv-v2-worker-01` joined tainted `node.homelab/class=worker-low-power:NoSchedule`. Longhorn had zero tolerations, so its CSI stack never scheduled there and pods on the worker failed to mount PVCs with `driver name driver.longhorn.io not found in the list of registered CSI drivers`. Datadog's node agent had the same gap, covering only the control plane.

**`stage2/longhorn-storage/templates/longhorn-values.tftpl`**

- `defaultSettings.taintToleration: "node.homelab/class:NoSchedule"`, covers Longhorn's system-managed components (CSI driver, instance-manager, engine-image). Value omitted so the operator is `Exists`, deliberate because taint values vary per worker (`worker_hosts_json` sets them per node), so matching on the key alone covers every current and future worker.
- `defaultSettings.createDefaultDiskLabeledNodes: true`, workers stay compute-only. Longhorn gives a default disk only to nodes labeled `node.longhorn.io/create-default-disk=true`, so replicas never land on a Pi's SD card. Safe on the running cluster because Longhorn evaluates this setting only the first time it detects a node; existing nodes and disks are untouched.
- `longhornManager.tolerations`, the one user-deployed component that must run wherever volumes mount (`defaultSettings.taintToleration` does not cover user-deployed components).
- An earlier revision of this branch also tolerated `longhornDriver` and `longhornUI`. Removed during review: both are Deployments with no reason to run on a worker, and the toleration only made them eligible. Confirmed against the live cluster, where both `longhorn-ui` replicas and `longhorn-driver-deployer` had in fact been scheduled onto the Raspberry Pi.

**`stage2/longhorn-storage/longhorn.tf`**

- New `data.kubernetes_nodes.control_plane` + `kubernetes_labels.longhorn_default_disk` codify the `node.longhorn.io/create-default-disk=true` label, with `helm_release.longhorn` depending on it. Previously this label existed only as a hand-run `kubectl label`, absent from the repo entirely; a cluster rebuild would come up with zero Longhorn disks and every PVC stuck Pending, with nothing failing at apply time to say why.
- Deliberately no `for_each` over the node list: this module carries a module-level `depends_on` in `main.tf`, which defers the data source read to apply whenever the upstream module has pending changes, leaving `for_each` keys unknown and failing the plan. Reproduced and the fix verified with a minimal Terraform repro.
- `force = true` adopts the pre-existing hand-applied label via server-side apply instead of erroring with a 409 conflict.

**`stage2/datadog/templates/datadog-agent.tftpl`**

- `override.nodeAgent.tolerations` so the node agent covers tainted workers.
- `features.npm.enabled: false`, NPM never emitted `network.*`/`dns.*` metrics or flows on this cluster, yet Datadog bills an NPM host monthly. Disabling it does not remove the `system-probe` container, which `features.oomKill` requires independently (verified against datadog-operator v1.19.0 source).

**Docs**

- `docs/adding-a-worker-node.md` verify step previously claimed workers run "only cilium, kube-proxy and node-exporter" and instructed pinning back anything else with a nodeSelector. Following it would have meant reverting this PR. Now lists the components that deliberately tolerate the taint.
- `stage2/longhorn-storage/README.md` gains a Node Topology section and an "Applying toleration changes" runbook.
- `stage2/datadog/README.md` records the NPM cost rationale.

## Operational note: taintToleration reads APPLIED=false

`defaultSettings.taintToleration` is a Longhorn Danger Zone setting (verified against Longhorn 1.10.1 docs and the live cluster). Longhorn will not reconcile it into a component that has running engines or replicas, so on a cluster with attached volumes the Setting CR can read `APPLIED=false` indefinitely.

This does not mean the toleration is missing. A newly joined node's instance-manager has no running engines, so it receives the toleration immediately. On the live cluster the csi-plugin DaemonSet does carry the toleration despite `APPLIED=false`. What lags is the control plane's own instance-manager, which is harmless since the control plane is untainted. Verify the component, not the flag.

## Verification

```bash
# CSI toleration is live on the worker, regardless of the Setting CR's APPLIED status
kubectl -n longhorn-system get ds longhorn-csi-plugin \
  -o jsonpath='{.spec.template.spec.tolerations}'

# Setting CR status. APPLIED may read false while volumes are attached, which is expected
kubectl -n longhorn-system get settings.longhorn.io taint-toleration

# longhorn-manager is scheduled on the worker
kubectl -n longhorn-system get pods -o wide -l app=longhorn-manager

# driver-deployer and UI stayed off the worker, no toleration added there
kubectl -n longhorn-system get pods -o wide -l app=longhorn-driver-deployer
kubectl -n longhorn-system get pods -o wide -l app=longhorn-ui

# default disk label present only on the control plane, and worker holds no replicas
kubectl get nodes -l node.longhorn.io/create-default-disk=true
kubectl -n longhorn-system get nodes.longhorn.io <worker> -o jsonpath='{.spec.disks}'

# a PVC mounts successfully on a pod scheduled to the worker
kubectl -n <namespace> describe pod <pod-on-worker> | grep -A5 Events

# Datadog node agent runs on the worker, system-probe still present for oomKill
kubectl -n datadog get pods -o wide -l app.kubernetes.io/component=agent
kubectl -n datadog get pod <agent-pod> -o jsonpath='{.spec.containers[*].name}'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Longhorn storage now supports dedicated node placement, labeled default-disk creation, and improved scheduling across tainted workers.
  * Datadog agents can run on tainted worker nodes while retaining required system monitoring.
* **Documentation**
  * Added guidance on worker verification, Longhorn node topology, toleration updates, reconciliation, and created resources.
  * Documented that Datadog Network Performance Monitoring is disabled and clarified related cost considerations.
* **Bug Fixes**
  * Prevented Longhorn from creating default disks on unintended nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->