### PR TITLE
fix: fix GitLab backup deadlock, gitaly typo, and right-size resources

### DIFF
--- a/docs/bitwarden-secrets-setup.md
+++ b/docs/bitwarden-secrets-setup.md
@@ -201,8 +201,9 @@ defaults, so substitute your own. **Gate** = only needed when that module's `*_e
 | `TF_VAR_gitlab_certmanager_issuer_email` | | `chris@chrislee.local` | Issuer email |
 | `TF_VAR_gitlab_postgresql_primary_persistence_size` | | `20Gi` | Postgres volume |
 | `TF_VAR_gitlab_redis_master_persistence_size` | | `20Gi` | Redis volume |
-| `TF_VAR_gitlab_gitlay_persistence_size` | | `20Gi` | Gitaly volume |
-| `TF_VAR_gitlab_toolbox_persistence_size` | | `40Gi` | Toolbox/backup volume |
+| `TF_VAR_gitlab_gitaly_persistence_size` | | `50Gi` | Gitaly volume. Backs a StatefulSet claim template, which is immutable, so this must match the existing volume |
+| `TF_VAR_gitlab_toolbox_persistence_size` | | `20Gi` | Toolbox volume |
+| `TF_VAR_gitlab_toolbox_backups_cron_persistence_size` | | `30Gi` | Backup staging volume |
 | `TF_VAR_gitlab_runner_authentication_token` | 🔑 | GitLab → Admin → CI/CD → Runners → New instance runner (allow untagged) | Registers the CI runner |
 | `TF_VAR_gitlab_minio_host` | | `minio.chrislee.local` | Object storage host |
 | `TF_VAR_gitlab_minio_endpoint` | | `https://minio.chrislee.local` | Object storage endpoint |

--- a/stage2/gitlab-platform/README.md
+++ b/stage2/gitlab-platform/README.md
@@ -115,6 +115,10 @@ sequenceDiagram
 - `kubernetes_secret.gitlab_toolbox_s3cmd` - Backup toolbox config
 - `kubernetes_secret.gitlab_auth0_provider` - Auth0 OIDC config
 
+### Storage
+
+- `kubernetes_storage_class_v1.gitlab_backup_ephemeral` - `Delete`-reclaim class for the nightly backup's ephemeral volume
+
 ### Helm Release
 
 - `helm_release.gitlab` - GitLab Helm chart
@@ -129,6 +133,7 @@ sequenceDiagram
 | `gitlab_global_hosts_host_suffix` | Subdomain suffix | `""` |
 | `gitlab_global_hosts_https` | Use HTTPS | `true` |
 | `gitlab_global_hosts_external_ip` | External LoadBalancer IP | `""` |
+| `gitlab_time_zone` | GitLab application timezone | `Australia/Melbourne` |
 
 ### Ingress Configuration
 
@@ -154,11 +159,11 @@ sequenceDiagram
 | Name | Description | Default |
 |------|-------------|---------|
 | `gitlab_persistence_storage_class_name` | Storage class | `longhorn` |
-| `gitlab_toolbox_backups_cron_persistence_size` | Backup PVC size | `20Gi` |
+| `gitlab_toolbox_backups_cron_persistence_size` | Backup staging volume size, per-pod ephemeral | `30Gi` |
 | `gitlab_toolbox_persistence_size` | Toolbox PVC size | `20Gi` |
 | `gitlab_postgresql_primary_persistence_size` | PostgreSQL PVC size | `20Gi` |
 | `gitlab_redis_master_persistence_size` | Redis PVC size | `20Gi` |
-| `gitlab_gitlay_persistence_size` | Gitaly PVC size | `20Gi` |
+| `gitlab_gitaly_persistence_size` | Gitaly PVC size | `50Gi` |
 
 ### CI/CD Runner
 
@@ -257,6 +262,14 @@ kubectl -n gitlab exec -it $(kubectl -n gitlab get pod -l app=toolbox -o name) -
 ### Scheduled Backups
 
 Backups are configured to run via CronJob and stored in MinIO `gitlab-backups` bucket.
+
+Each run stages its tarball on its own generic ephemeral volume, garbage-collected with the pod, so
+no shared claim can wedge the schedule. That volume uses a dedicated `Delete`-reclaim StorageClass
+(`backup-storageclass.tf`); the shared `longhorn` class is `Retain` and would strand a volume nightly.
+
+Jobs are capped at 3h (`activeDeadlineSeconds: 10800`), generous against a healthy run. Without a
+deadline a stuck backup runs indefinitely, and `concurrencyPolicy: Replace` then deletes it on the
+next schedule, leaving no failed job behind to notice.
 
 ## Troubleshooting
 

--- a/stage2/gitlab-platform/backup-storageclass.tf
+++ b/stage2/gitlab-platform/backup-storageclass.tf
@@ -1,0 +1,42 @@
+# Dedicated class for the nightly backup's generic ephemeral volume.
+#
+# The shared `longhorn` class is reclaimPolicy: Retain, which is correct for gitaly/postgres/redis
+# where an accidental PVC deletion must not destroy data. It is wrong here: a generic ephemeral
+# volume's PVC is owned by its pod, so pruning yesterday's job deletes the PVC, and Retain then
+# leaves the PV Released forever. That would strand one Longhorn volume, holding a full backup
+# tarball, every night.
+#
+# Parameters mirror the `longhorn` class so the volume behaves identically apart from reclaim.
+# Do not substitute the built-in `longhorn-static` class: it omits numberOfReplicas and would
+# inherit the global default replica count.
+resource "kubernetes_storage_class_v1" "gitlab_backup_ephemeral" {
+  metadata {
+    name = "longhorn-gitlab-backup-ephemeral"
+
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/part-of"    = "homelab"
+    }
+  }
+
+  storage_provisioner = "driver.longhorn.io"
+
+  # The whole point of this class. Note the provider has no ForceNew on reclaim_policy and its
+  # update only patches metadata and allow_volume_expansion, so editing this in place would plan a
+  # silent no-op and re-diff forever. Replace the resource instead.
+  reclaim_policy = "Delete"
+
+  # Kubernetes recommends late binding for generic ephemeral volumes: it leaves the scheduler free
+  # to place the pod, and avoids provisioning a volume for a pod that never schedules.
+  volume_binding_mode = "WaitForFirstConsumer"
+
+  allow_volume_expansion = true
+
+  parameters = {
+    numberOfReplicas    = "1"
+    staleReplicaTimeout = "30"
+    fromBackup          = ""
+    fsType              = "ext4"
+    dataLocality        = "disabled"
+  }
+}

--- a/stage2/gitlab-platform/gitlab.tf
+++ b/stage2/gitlab-platform/gitlab.tf
@@ -84,13 +84,14 @@ resource "helm_release" "gitlab" {
 
         persistence_storage_class_name = var.gitlab_persistence_storage_class_name
 
-        toolbox_backups_cron_persistence_size = var.gitlab_toolbox_backups_cron_persistence_size
-        toolbox_persistence_size              = var.gitlab_toolbox_persistence_size
+        toolbox_backups_cron_persistence_size   = var.gitlab_toolbox_backups_cron_persistence_size
+        toolbox_backups_cron_storage_class_name = kubernetes_storage_class_v1.gitlab_backup_ephemeral.metadata[0].name
+        toolbox_persistence_size                = var.gitlab_toolbox_persistence_size
 
         postgresql_primary_persistence_size = var.gitlab_postgresql_primary_persistence_size
 
         redis_master_persistence_size = var.gitlab_redis_master_persistence_size
-        gitlay_persistence_size       = var.gitlab_gitlay_persistence_size
+        gitaly_persistence_size       = var.gitlab_gitaly_persistence_size
 
         # Auth0 configuration
         auth0_provider_secret = kubernetes_secret_v1.gitlab_auth0_provider.metadata[0].name

--- a/stage2/gitlab-platform/templates/gitlab-values.tftpl
+++ b/stage2/gitlab-platform/templates/gitlab-values.tftpl
@@ -432,7 +432,12 @@ certmanager-issuer:
 
 ## Installation & configuration of jetstack/cert-manager
 ## See requirements.yaml for current version
-## Note: install and rbac properties removed in GitLab chart 9.x - using external cert-manager
+## The cluster already runs cert-manager in its own namespace, so the bundled copy is not wanted.
+## chart 9.x renamed `certmanager.install` to the top-level `installCertmanager` (Chart.yaml gates
+## the dependency on it). Leaving it unset kept the default of true, so a second, redundant
+## cert-manager ran here in leader-election standby.
+installCertmanager: false
+
 certmanager:
   installCRDs: false
 
@@ -785,6 +790,22 @@ gitlab-runner:
           namespace = "{{.Release.Namespace}}"
           image = "docker:stable"
           privileged = true
+          # Without these, job pods are BestEffort and invisible to the scheduler: it cannot
+          # account for them, so concurrent jobs overcommit the node. Requests sit near the typical
+          # job and limits well above it, so they bound a runaway rather than throttle normal
+          # builds. Re-derive both from actual job usage before changing them.
+          cpu_request = "200m"
+          cpu_limit = "2"
+          memory_request = "512Mi"
+          memory_limit = "5Gi"
+          helper_cpu_request = "50m"
+          helper_cpu_limit = "500m"
+          helper_memory_request = "128Mi"
+          helper_memory_limit = "3Gi"
+          service_cpu_request = "50m"
+          service_cpu_limit = "1"
+          service_memory_request = "128Mi"
+          service_memory_limit = "2Gi"
           [runners.cache]
             Type = "s3"
             Path = "gitlab-runner"
@@ -820,16 +841,22 @@ traefik:
 ## Settings for individual sub-charts under GitLab
 ## Note: Many of these settings are configurable via globals
 gitlab:
-  gitlay:
-    enabled: true
+  # Was misspelled "gitlay" since the initial commit. The chart has no such key, so Helm silently
+  # discarded this whole block: gitaly kept the chart default 50Gi and was never scraped.
+  # Do not add `enabled` here. Chart 9.11.3 removed `gitlab.gitaly.enabled` and its removal check
+  # fires on the key existing at all, at any value, failing the upgrade. It lives at
+  # `global.gitaly.enabled` instead, which is already set above.
+  gitaly:
     persistence:
-      size: ${gitlay_persistence_size}
+      # Backs a StatefulSet volumeClaimTemplate, which Kubernetes forbids updating, so this must
+      # match the volume gitaly already has.
+      size: ${gitaly_persistence_size}
     metrics:
       enabled: true
       port: 9236
       path: /metrics
       serviceMonitor:
-        enabled: truie
+        enabled: true
         additionalLabels:
           release: kube-prometheus-stack
         endpointConfig: {}
@@ -843,7 +870,15 @@ gitlab:
         concurrencyPolicy: Replace
         failedJobsHistoryLimit: 1
         schedule: "0 1 * * *"
-        successfulJobsHistoryLimit: 3
+        # Each retained pod owns its own ephemeral volume (see useGenericEphemeralVolume below) and
+        # holds it until the pod is deleted, not until the job finishes. Peak demand is therefore
+        # this limit + failedJobsHistoryLimit + the running job, so 1 here keeps the worst case at
+        # 3x the volume size rather than 5x.
+        successfulJobsHistoryLimit: 1
+        # Bound a stuck job. Without a deadline a Pending backup runs indefinitely, and
+        # concurrencyPolicy Replace then deletes it nightly, leaving no failed job behind to notice.
+        # Generous against a healthy run, which finishes well inside this.
+        activeDeadlineSeconds: 10800
         extraArgs: "--skip registry --skip artifacts"
         suspend: false
         backoffLimit: 6
@@ -856,8 +891,13 @@ gitlab:
         persistence:
           enabled: true
           accessMode: ReadWriteOnce
-          storageClass: ${persistence_storage_class_name}
-          useGenericEphemeralVolume: false
+          # Not the shared `longhorn` class: that one is reclaimPolicy Retain, which would leave a
+          # Released PV holding a backup tarball every night once the pod's ephemeral PVC is GC'd.
+          storageClass: ${toolbox_backups_cron_storage_class_name}
+          # A single ReadWriteOnce PVC would be shared by every backup pod, so one stuck pod holds
+          # it and every replacement stays Pending, wedging the schedule indefinitely. Giving each
+          # pod its own volume removes the shared claim, so no one pod can wedge the next run.
+          useGenericEphemeralVolume: true
           size: ${toolbox_backups_cron_persistence_size}
       objectStorage:
         backend: s3
@@ -875,6 +915,13 @@ gitlab:
   webservice:
     enabled: true
     minReplicas: 1
+    # The chart disables the puma worker killer by default, so workers grow until the cgroup
+    # OOM-kills the pod. Re-enabling it with a per-worker cap restarts a worker gracefully instead,
+    # which both removes the OOM and lowers steady-state memory. Keep workerProcesses x
+    # workerMaxMemory, plus the primary, under limits.memory below.
+    puma:
+      disableWorkerKiller: false
+      workerMaxMemory: 900
     resources:
       requests:
         memory: 500Mi
@@ -894,12 +941,19 @@ gitlab:
     %{ endif }
   sidekiq:
     enabled: true
+    # maxRss must stay below limits.memory or the memory killer can never fire. GitLab converts this
+    # with Rails .kilobytes, so 1 KB is 1024 B: the chart default of 2000000 KB is ~1953Mi, above the
+    # 1.5Gi limit, so the cgroup OOM always won and the graceful restart was unreachable.
+    # 1200000 KB (~1172Mi) leaves room for memory to grow during graceTime while the process drains
+    # in-flight jobs.
+    memoryKiller:
+      maxRss: 1200000
     resources:
       requests:
-        memory: 750Mi      # Increased for GitLab 18.8.x baseline usage
+        memory: 750Mi
         cpu: 0
       limits:
-        memory: 1.5Gi      # Increased from 1Gi to prevent OOM kills
+        memory: 1.5Gi
         cpu: 1
     metrics:
       enabled: true

--- a/stage2/gitlab-platform/variables.tf
+++ b/stage2/gitlab-platform/variables.tf
@@ -114,10 +114,12 @@ variable "gitlab_redis_master_persistence_size" {
   default     = "20Gi"
 }
 
-variable "gitlab_gitlay_persistence_size" {
-  description = "The size of the gitlay persistence"
+variable "gitlab_gitaly_persistence_size" {
+  description = "The size of the gitaly persistence"
   type        = string
-  default     = "20Gi"
+  # Backs a StatefulSet volumeClaimTemplate, which cannot be updated. Must match gitaly's existing
+  # volume, which is 50Gi because the misspelled "gitlay" key left the chart default in force.
+  default = "50Gi"
 }
 
 variable "gitlab_runner_authentication_token" {

--- a/stage2/main.tf
+++ b/stage2/main.tf
@@ -118,7 +118,7 @@ module "gitlab_platform" {
 
   gitlab_postgresql_primary_persistence_size = var.gitlab_postgresql_primary_persistence_size
   gitlab_redis_master_persistence_size       = var.gitlab_redis_master_persistence_size
-  gitlab_gitlay_persistence_size             = var.gitlab_gitlay_persistence_size
+  gitlab_gitaly_persistence_size             = var.gitlab_gitaly_persistence_size
 
   gitlab_runner_authentication_token = var.gitlab_runner_authentication_token
 

--- a/stage2/monitoring/templates/prometheus-stack-values.tftpl
+++ b/stage2/monitoring/templates/prometheus-stack-values.tftpl
@@ -22,6 +22,15 @@ crds:
 ##
 alertmanager:
   enabled: true
+  alertmanagerSpec:
+    ## Chart default is resources: {}, so this runs unaccounted. Sized from actual usage on a
+    ## small single-cluster install; re-derive before reusing elsewhere.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 192Mi
   ## Alertmanager configuration directives
   ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
   ##      https://prometheus.io/webtools/alerting/routing-tree-editor/
@@ -131,6 +140,22 @@ grafana:
   enabled: true
   defaultDashboardsTimezone: Australia/Melbourne
   adminPassword: ${grafana_admin_password}
+  ## Chart default is resources: {}, so this runs unaccounted. Sized from actual usage on a
+  ## small single-cluster install; re-derive before reusing elsewhere.
+  resources:
+    requests:
+      cpu: 10m
+      memory: 192Mi
+    limits:
+      memory: 320Mi
+  ## One shared key covers both the dashboard and datasource sidecars.
+  sidecar:
+    resources:
+      requests:
+        cpu: 5m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
   datasources: {}
   dashboardProviders:
     dashboardproviders.yaml:
@@ -205,6 +230,27 @@ grafana:
 prometheus:
   enabled: true
   prometheusSpec:
+    ## The chart ships resources: {} so this runs unaccounted. Sized from actual usage on a small
+    ## single-cluster install; re-derive before reusing elsewhere. Note there is no storageSpec
+    ## below, so Prometheus runs on emptyDir and every redeploy resets its history regardless of
+    ## the retention setting: any sizing window has to be captured externally while it lasts.
+    ## No CPU limit: scrape and rule evaluation are latency-sensitive and throttling them
+    ## silently produces gaps in the very data used to size everything else.
+    resources:
+      requests:
+        cpu: 100m
+        ## Deliberately above steady-state usage. The kubelet evicts Burstable pods that exceed
+        ## their request first, ranked by how far over they are, so a request set under normal
+        ## usage puts Prometheus at the front of the queue under node pressure. On emptyDir that
+        ## costs every sample it holds.
+        memory: 1750Mi
+      limits:
+        ## Well clear of steady state, not a snug fit. WAL replay after a restart allocates above
+        ## steady state, so a limit near the normal peak can OOM during replay and crashloop
+        ## instead of recovering. A crashlooping Prometheus evaluates no rules, so nothing alerts
+        ## on it. Refs prometheus/prometheus#6934.
+        memory: 3Gi
+
     ## ServiceMonitors to be selected for target discovery.
     ## If matchLabels.release: "{{ $.Release.Name }}" the prometheus resource will be created
     ## with selectors based on values in the helm deployment, which will also match the scrapeConfigs created

--- a/stage2/nginx/templates/nginx-values.tftpl
+++ b/stage2/nginx/templates/nginx-values.tftpl
@@ -9,6 +9,9 @@ controller:
   addHeaders:
     Referrer-Policy: strict-origin-when-cross-origin
   config:
+    # Defaults to "auto", one worker per host core, each holding its own memory. That scales with
+    # the node rather than with the traffic, which for a homelab-sized ingress load is waste.
+    worker-processes: "2"
     annotation-value-word-blocklist: "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},',\""
     hsts: "true"
     hsts-include-subdomains: "false"

--- a/stage2/variables.tf
+++ b/stage2/variables.tf
@@ -306,16 +306,18 @@ variable "gitlab_redis_master_persistence_size" {
   }
 }
 
-variable "gitlab_gitlay_persistence_size" {
-  description = "The size of the gitlay persistence"
+variable "gitlab_gitaly_persistence_size" {
+  description = "The size of the gitaly persistence"
   type        = string
-  default     = "20Gi"
+  # Backs a StatefulSet volumeClaimTemplate, which cannot be updated. Must match gitaly's existing
+  # volume, which is 50Gi because the misspelled "gitlay" key left the chart default in force.
+  default = "50Gi"
 
   # Validate Kubernetes storage size format per Kubernetes quantity spec
   # Ref: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/
   validation {
-    condition     = can(regex("^([0-9]+(\\.[0-9]+)?)(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)$", var.gitlab_gitlay_persistence_size))
-    error_message = "Must be a valid Kubernetes storage size (e.g., 20Gi, 1.5Ti, 500Mi)"
+    condition     = can(regex("^([0-9]+(\\.[0-9]+)?)(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)$", var.gitlab_gitaly_persistence_size))
+    error_message = "Must be a valid Kubernetes storage size (e.g., 50Gi, 1.5Ti, 500Mi)"
   }
 }
 


### PR DESCRIPTION
## Why

Right-sizing the cluster's resource requests surfaced three latent GitLab platform defects, plus general resource visibility gaps.

1. **Backups silently failing for months.** A single ReadWriteOnce PVC is shared by every nightly backup pod. One stuck pod held the claim, so every replacement job stayed `Pending`. `concurrencyPolicy: Replace` then deleted the failed job on the next schedule, leaving nothing behind to notice.
2. **`gitlay` typo since the initial commit.** Helm has no such key under `gitlab.gitaly`, so the entire block was silently discarded: gitaly kept the chart's 50Gi default and its `ServiceMonitor` was never created, meaning the component storing every git repo was never scraped. A second typo, `enabled: truie`, was in the same block.
3. **Redundant standby cert-manager.** `installCertmanager` was unset (chart 9.x renamed `certmanager.install` to a top-level key), so the chart's bundled cert-manager ran alongside the cluster's own, sitting idle in leader-election standby.

Also included: resource requests/limits for components the chart ships with `resources: {}` (Prometheus, Alertmanager, Grafana + sidecars, gitlab-runner job pods), so they stop being invisible to the scheduler; puma worker killer re-enabled with a per-worker cap; sidekiq `memoryKiller.maxRss` lowered below `limits.memory` so the graceful restart can actually fire before the cgroup OOM does; nginx pinned to 2 worker processes instead of one per host core; and doc corrections for stale/incorrect variable defaults.

```mermaid
flowchart LR
  classDef bad fill:#7f1d1d,color:#ffffff
  classDef good fill:#14532d,color:#ffffff

  subgraph before["Before"]
    B1["Shared RWO backup PVC"]:::bad --> B2["Stuck pod holds claim<br/>replacements stay Pending"]:::bad
    B2 --> B3["concurrencyPolicy Replace<br/>deletes failed job nightly"]:::bad
    B4["gitlab.gitlay typo"]:::bad --> B5["Block silently discarded<br/>gitaly unmonitored"]:::bad
    B6["installCertmanager unset"]:::bad --> B7["Second cert-manager<br/>idle standby"]:::bad
    A1["useGenericEphemeralVolume true<br/>plus dedicated Delete StorageClass"]:::good --> A2["Each pod owns its volume<br/>no shared claim to wedge"]:::good
    A3["activeDeadlineSeconds 10800"]:::good --> A4["Stuck job bounded,<br/>fails visibly"]:::good
    A5["gitlab.gitaly corrected"]:::good --> A6["50Gi pinned, ServiceMonitor created"]:::good
    A7["installCertmanager false"]:::good --> A8["Single cluster cert-manager"]:::good
  end
```

## Constraints

- `gitlab_gitaly_persistence_size` default is 50Gi and **must stay 50Gi**: it backs a `StatefulSet` `volumeClaimTemplate`, which Kubernetes forbids updating, and the live volume is already 50Gi.
- Do **not** add `enabled` under `gitlab.gitaly`: chart 9.11.3's removal check fires on the key existing at any value and fails the upgrade. Gitaly's enablement lives at `global.gitaly.enabled`, already set.
- The new StorageClass exists because the shared `longhorn` class is `reclaimPolicy: Retain`. A generic ephemeral volume's PVC is owned by its pod, so under `Retain` every pruned backup pod would leave a `Released` PV holding a tarball. `Retain` remains correct for gitaly/postgres/redis, hence a separate class rather than a change to the shared one.

## Deployment

- [x] All Helm values changes are already applied to the live cluster and verified
- [ ] New `kubernetes_storage_class_v1.gitlab_backup_ephemeral` StorageClass is not yet applied — requires `terraform apply`
- [ ] After applying, reclaim the one ephemeral backup PVC created before the StorageClass existed: it still sits on the `Retain` class and will leave a `Released` PV when its job pod is pruned (`kubectl get pv | grep Released`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated ephemeral storage for nightly GitLab backups, with automatic cleanup of completed backup volumes.
  - Improved backup scheduling safeguards to prevent stuck or orphaned jobs.
  - Added resource sizing for GitLab runners, monitoring services, and workloads.

- **Bug Fixes**
  - Corrected Gitaly storage configuration and increased its default capacity to 50 GiB.
  - Fixed Gitaly metrics and monitoring configuration.
  - Prevented redundant installation of cert-manager when already available.

- **Documentation**
  - Expanded configuration guidance for storage, persistence, time zones, and backup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->