### PR TITLE
chore(stage2): right-size CPU requests/limits across modules

### DIFF
--- a/stage2/auth/templates/oauth2-proxy.tftpl
+++ b/stage2/auth/templates/oauth2-proxy.tftpl
@@ -58,12 +58,17 @@ ingress:
         - ${oauth2_proxy_host}
   %{ endif }
 
+# The proxy idles near zero and only spikes on token exchange, so the request sits well under the
+# limit rather than booking the burst ceiling. Trap: a CPU request below the CPU limit puts the pod
+# in Burstable, not Guaranteed, which raises its oom_score_adj. Auth still fails closed (nginx
+# auth_request denies on any non-2xx), so losing this pod 500s every protected ingress rather than
+# opening one. Set request == limit on both cpu and memory to get Guaranteed back.
 resources:
   limits:
     cpu: 100m
     memory: 300Mi
   requests:
-    cpu: 100m
+    cpu: 25m
     memory: 300Mi
 
 

--- a/stage2/gitlab-platform/templates/gitlab-values.tftpl
+++ b/stage2/gitlab-platform/templates/gitlab-values.tftpl
@@ -711,7 +711,11 @@ shared-secrets:
 ## https://gitlab.com/gitlab-org/charts/gitlab-runner/blob/main/values.yaml
 gitlab-runner:
   install: true
-  concurrent: 3
+  # A job pod costs ~350m assuming two services: build 200m + helper 50m + 2 x service 50m, from
+  # the cpu_request values below. Keep concurrent * 350m inside the node's free CPU, or job pods
+  # sit Pending and fail as runner_system_failure when poll_timeout expires (default 180s, not
+  # overridden here).
+  concurrent: 2
   rbac:
     create: true
   envVars:

--- a/stage2/longhorn-storage/templates/longhorn-values.tftpl
+++ b/stage2/longhorn-storage/templates/longhorn-values.tftpl
@@ -20,6 +20,17 @@ defaultSettings:
   defaultReplicaCount: 1
   backupCompressionMethod: "gzip"
   snapshotMaxCount: 3
+  # Percentage of node allocatable CPU reserved per instance-manager pod, so managers stranded
+  # across engine-image versions multiply it. Longhorn's instances*0.1/cores formula sizes for full
+  # I/O saturation this cluster never reaches. Longhorn accepts 0-40 and 0 removes the request
+  # entirely; 5 is our own floor, not a Longhorn rule. Raise it if volumes start timing out or
+  # rebuilding. v2 stays at the 12 default because the V2 data engine is not enabled here.
+  # Danger Zone setting: the value lands on the Setting CR immediately, but Longhorn defers pushing
+  # it to the instance-manager pods until every engine instance is stopped, retrying until then.
+  # Check APPLIED on the Setting CR, not VALUE.
+  # Raising or lowering this also moves LonghornInstanceManagerCPUUsageWarning, which alerts on
+  # usage as a percentage of this request. See stage2/monitoring/prometheus-rules/longhorn-rules.tftpl.
+  guaranteedInstanceManagerCPU: '{"v1":"8","v2":"12"}'
   # Covers system-managed components only (CSI driver, instance-manager, engine-image).
   # Omitting the value means operator Exists, which is deliberate: taint values vary per
   # worker (worker_hosts_json sets them per node, e.g. worker-low-power), so matching on the

--- a/stage2/monitoring-kubecost/templates/kubecost-values.tftpl
+++ b/stage2/monitoring-kubecost/templates/kubecost-values.tftpl
@@ -51,9 +51,27 @@ aggregator:
   # quarter. Only daily resolution is worth keeping this long; retention1h and retention10m stay at
   # their defaults because the agent's hourly files age out within two days anyway.
   retention1d: 700
+  resources:
+    # Chart leaves limits empty, so ETL bursts are unbounded. Capping costs ETL wall-clock on the
+    # tail, not readiness. The chart's 100m/3Gi requests are left alone. Raise if ingestion lags.
+    limits:
+      cpu: 1000m
 
+# finops-agent subchart requests 500m/512Mi, sized for a multi-node cluster. Only the requests are
+# lowered; its 2Gi memory limit stays as the backstop.
 finopsagent:
   enabled: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
   persistence:
     enabled: true
     size: 8Gi
+
+forecasting:
+  resources:
+    requests:
+      # Chart default 200m books more than this cluster's forecasting workload draws. Memory
+      # request and both limits (1500m/1Gi) stay at chart defaults.
+      cpu: 50m

--- a/stage2/monitoring/prometheus-rules/longhorn-rules.tftpl
+++ b/stage2/monitoring/prometheus-rules/longhorn-rules.tftpl
@@ -70,6 +70,8 @@ spec:
       labels:
         issue: There are {{$value}} Longhorn nodes are offline
         severity: critical
+    # The denominator is guaranteedInstanceManagerCPU from the longhorn-storage module, so lowering
+    # that setting raises this ratio for unchanged usage. Re-derive the threshold if it moves again.
     - alert: LonghornInstanceManagerCPUUsageWarning
       annotations:
         description: Longhorn instance manager {{$labels.instance_manager}} on {{$labels.node}} has CPU Usage / CPU request is {{$value}}% for


### PR DESCRIPTION
Adjusts Kubernetes CPU resource requests and limits in Helm values templates across several stage2 Terraform modules, where requests were higher than needed, and documents the reasoning inline for future changes.

- `stage2/auth`: lowers the oauth2-proxy CPU request; explains the Guaranteed-QoS tradeoff of request-vs-limit sizing
- `stage2/gitlab-platform`: lowers GitLab Runner `concurrent` job count; documents the per-job CPU cost used to size it
- `stage2/longhorn-storage`: adds the `guaranteedInstanceManagerCPU` setting to reserve a defined CPU share per instance-manager pod; documents the Danger Zone apply semantics and its coupling to a related alert threshold
- `stage2/monitoring-kubecost`: adds a CPU limit on the aggregator, and lowers CPU requests for the finops-agent and forecasting components
- `stage2/monitoring`: adds a comment on the Longhorn instance-manager CPU alert noting its threshold is relative to the `guaranteedInstanceManagerCPU` setting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance & Reliability**
  - Optimized CPU and memory allocations for authentication, monitoring, and storage services.
  - Reduced GitLab Runner job concurrency to improve scheduling reliability and prevent pending jobs from timing out.
  - Added CPU reservation settings for storage instance managers.
  - Applied resource limits and requests to Kubecost components while preserving FinOps data retention.

- **Monitoring**
  - Updated Longhorn CPU usage alert guidance to reflect the new reservation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->